### PR TITLE
Formally declare our dependency on Atom 1.19 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "dependencies": {
     "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.7.12",
     "loophole": "^1.1.0"
+  },
+  "engines": {
+    "atom": ">=1.19.0"
   }
 }


### PR DESCRIPTION
@as-cii: Since the package doesn't support version of Atom older than 1.19, does it make sense to reflect that fact in package.json? 