### PR TITLE
Remove obsolete CSP workaround

### DIFF
--- a/lib/real-time-package.js
+++ b/lib/real-time-package.js
@@ -1,13 +1,6 @@
 const path = require('path')
-
 const {CompositeDisposable} = require('atom')
-const {allowUnsafeNewFunction} = require('loophole')
-
-// Bypass CSP errors caused by Protobuf in Tachyon.
-// TODO: Remove this once Atom 1.20 reaches stable.
-let Client
-allowUnsafeNewFunction(() => { Client = require('@atom/real-time-client') })
-
+const Client = require('@atom/real-time-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const GuestPortalBinding = require('./guest-portal-binding')

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.13.2",
-    "loophole": "^1.1.0"
+    "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.13.2"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
Now that Atom 1.20 stable has been released, we no longer need this workaround.