### PR TITLE
Clear selections tail when they become empty after a text change

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -197,6 +197,7 @@ function isHost (siteId) {
 function getSelectionState (marker) {
   return {
     range: marker.getRange(),
+    exclusive: marker.isExclusive(),
     reversed: marker.isReversed()
   }
 }


### PR DESCRIPTION
Depends on https://github.com/atom/text-buffer/pull/261
Fixes #61 

Originally, we attempted to solve this by relaying the `exclusive` parameter from the site owning the marker. This was, however, inaccurate because selections only become exclusive if text changes and the selected region becomes empty.

For this reason, similarly to what we do in [selection.coffee](https://github.com/atom/atom/blob/a3e98d54e3d24bbc5c4a67a135cfae2744805285/src/selection.coffee), we will observe all selection markers, and if they move as a result of a text change, we will clear the tail if their range becomes empty.

/cc: @nathansobo @jasonrudolph @ungb @rsese @Ben3eeE 