### PR TITLE
Prevent empty portal pane item from being serialized or copied

### DIFF
--- a/lib/empty-portal-pane-item.js
+++ b/lib/empty-portal-pane-item.js
@@ -1,0 +1,44 @@
+const {Emitter} = require('atom')
+
+module.exports =
+class EmptyPortalPaneItem {
+  constructor () {
+    this.emitter = new Emitter()
+    this.element = document.createElement('div')
+    this.element.tabIndex = -1
+    this.element.classList.add('realtime-RemotePaneItem')
+    this.element.style.position = 'absolute'
+    this.element.style.width = '100%'
+    this.element.style.top = '50%'
+    this.element.style.fontSize = '24px'
+    this.element.style.textAlign = 'center'
+    // TODO: Replace "host" with the person's first name (or @username) once we
+    // implement authentication.
+    this.element.innerHTML = `
+      Your host is doing something else right now.<br/>
+      Sharing will resume once the host is editing again.
+    `
+  }
+
+  copy () {
+    // Prevents item from being copied.
+    return null
+  }
+
+  serialize () {
+    // Prevents item from being serialized.
+    return null
+  }
+
+  getTitle () {
+    return 'Portal: No Active File'
+  }
+
+  destroy () {
+    this.emitter.emit('did-destroy')
+  }
+
+  onDidDestroy (callback) {
+    return this.emitter.once('did-destroy', callback)
+  }
+}

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -1,8 +1,9 @@
-const {CompositeDisposable, Emitter, TextEditor, TextBuffer} = require('atom')
+const {CompositeDisposable, TextEditor, TextBuffer} = require('atom')
 const {Errors} = require('@atom/real-time-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const GuestPortalBinding = require('./guest-portal-binding')
+const EmptyPortalPaneItem = require('./empty-portal-pane-item')
 
 module.exports =
 class GuestPortalBinding {
@@ -156,37 +157,5 @@ class GuestPortalBinding {
 
   getActivePaneItem () {
     return this.newActivePaneItem ? this.newActivePaneItem : this.activePaneItem
-  }
-}
-
-class EmptyPortalPaneItem {
-  constructor () {
-    this.emitter = new Emitter()
-    this.element = document.createElement('div')
-    this.element.tabIndex = -1
-    this.element.classList.add('realtime-RemotePaneItem')
-    this.element.style.position = 'absolute'
-    this.element.style.width = '100%'
-    this.element.style.top = '50%'
-    this.element.style.fontSize = '24px'
-    this.element.style.textAlign = 'center'
-    // TODO: Replace "host" with the person's first name (or @username) once we
-    // implement authentication.
-    this.element.innerHTML = `
-      Your host is doing something else right now.<br/>
-      Sharing will resume once the host is editing again.
-    `
-  }
-
-  getTitle () {
-    return 'Portal: No Active File'
-  }
-
-  destroy () {
-    this.emitter.emit('did-destroy')
-  }
-
-  onDidDestroy (callback) {
-    return this.emitter.once('did-destroy', callback)
   }
 }

--- a/test/empty-portal-pane-item.test.js
+++ b/test/empty-portal-pane-item.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert')
+const EmptyPortalPaneItem = require('../lib/empty-portal-pane-item')
+
+const suite = global.describe
+const test = global.it
+
+suite('EmptyPortalPaneItem', () => {
+  test('copy()', () => {
+    const paneItem = new EmptyPortalPaneItem()
+    assert.equal(paneItem.copy(), null)
+  })
+
+  test('serialize()', () => {
+    const paneItem = new EmptyPortalPaneItem()
+    assert.equal(paneItem.serialize(), null)
+  })
+})


### PR DESCRIPTION
Fixes #53

This also extracts `EmptyPortalPaneItem` so that we can test it in isolation.

/cc: @nathansobo @jasonrudolph @ungb @rsese @Ben3eeE 