### PR TITLE
Change server URL to api.tachyon.atom.io

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const PRODUCTION_REAL_TIME_PUSHER_KEY = 'f119821248b7429bece3'
-const PRODUCTION_REAL_TIME_BASE_URL = 'https://atom-tachyon.herokuapp.com'
+const PRODUCTION_REAL_TIME_BASE_URL = 'https://api.tachyon.atom.io'
 
 const RealTimePackage = require('./lib/real-time-package')
 module.exports = new RealTimePackage({


### PR DESCRIPTION
Closes https://github.com/atom/real-time/issues/50.

---

Now that https://github.com/github/dns/pull/752 has shipped, we can access the server at https://api.tachyon.atom.io.

As far as I can tell, across all four repos, we only specify the production server URL in one place. 😅  This PR updates that one-and-only place to use the new URL.