### PR TITLE
Style cursors using theme's collaboration colors

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -22,6 +22,7 @@ class EditorBinding {
     this.markerLayersBySiteId.forEach((l) => l.destroy())
     this.markerLayersBySiteId.clear()
     if (!this.isHost) this.restoreOriginalEditorMethods(this.editor)
+    if (this.localCursorLayerDecoration) this.localCursorLayerDecoration.destroy()
     this.emitDidDispose()
   }
 
@@ -38,6 +39,11 @@ class EditorBinding {
     }
     this.subscriptions.add(this.selectionsMarkerLayer.onDidCreateMarker(this.observeMarker.bind(this)))
     this.relayLocalSelections()
+
+    this.localCursorLayerDecoration = this.editor.decorateMarkerLayer(
+      this.selectionsMarkerLayer,
+      {type: 'cursor', class: cursorClassForSiteId(editorProxy.siteId)}
+    )
   }
 
   monkeyPatchEditorMethods (editor, editorProxy) {
@@ -102,7 +108,7 @@ class EditorBinding {
     let markerLayer = this.markerLayersBySiteId.get(siteId)
     if (!markerLayer) {
       markerLayer = this.editor.addMarkerLayer()
-      this.editor.decorateMarkerLayer(markerLayer, {type: 'cursor', style: {borderLeftColor: colorForSiteId(siteId)}})
+      this.editor.decorateMarkerLayer(markerLayer, {type: 'cursor', class: cursorClassForSiteId(siteId)})
       this.editor.decorateMarkerLayer(markerLayer, {type: 'highlight', class: 'selection'})
       this.markerLayersBySiteId.set(siteId, markerLayer)
     }
@@ -183,15 +189,6 @@ class EditorBinding {
   }
 }
 
-const COLORS = [
-  '#2ECC40', '#FF851B', '#85144b', '#FFDC00', '#39CCCC', '#0074D9', '#3D9970',
-  '#001f3f', '#FF4136', '#F012BE', '#01FF70', '#B10DC9', '#7FDBFF', '#111111'
-]
-
-function colorForSiteId (siteId) {
-  return COLORS[(siteId - 1) % COLORS.length]
-}
-
 function isHost (siteId) {
   return siteId === 1
 }
@@ -202,4 +199,8 @@ function getSelectionState (marker) {
     exclusive: marker.isExclusive(),
     reversed: marker.isReversed()
   }
+}
+
+function cursorClassForSiteId (siteId) {
+  return `ParticipantCursor--site-${siteId}`
 }

--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -231,3 +231,65 @@
     margin-left: 5px;
   }
 }
+
+.cursor.ParticipantCursor {
+  &--site-1 {
+    border-left-color: @ui-site-color-1;
+  }
+
+  &--site-2 {
+    border-left-color: @ui-site-color-2;
+  }
+
+  &--site-3 {
+    border-left-color: @ui-site-color-3;
+  }
+
+  &--site-4 {
+    border-left-color: @ui-site-color-4;
+  }
+
+  &--site-5 {
+    border-left-color: @ui-site-color-5;
+  }
+
+  &--site-6 {
+    border-left-color: spin(@ui-site-color-1, 25);
+  }
+
+  &--site-7 {
+    border-left-color: spin(@ui-site-color-2, 25);
+  }
+
+  &--site-8 {
+    border-left-color: spin(@ui-site-color-3, 25);
+  }
+
+  &--site-9 {
+    border-left-color: spin(@ui-site-color-4, 25);
+  }
+
+  &--site-10 {
+    border-left-color: spin(@ui-site-color-5, 25);
+  }
+
+  &--site-11 {
+    border-left-color: spin(@ui-site-color-1, 65);
+  }
+
+  &--site-12 {
+    border-left-color: spin(@ui-site-color-2, 65);
+  }
+
+  &--site-13 {
+    border-left-color: spin(@ui-site-color-3, 65);
+  }
+
+  &--site-14 {
+    border-left-color: spin(@ui-site-color-4, 65);
+  }
+
+  &--site-15 {
+    border-left-color: spin(@ui-site-color-5, 65);
+  }
+}

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -349,6 +349,28 @@ suite('EditorBinding', function () {
     })
   })
 
+  test('decorates each cursor with a site-specific class name', () => {
+    const editor = new TextEditor()
+    editor.setText(SAMPLE_TEXT)
+    const binding = new EditorBinding({editor})
+    const editorProxy = new FakeEditorProxy(binding, {siteId: 2})
+
+    binding.setEditorProxy(editorProxy)
+    assert.deepEqual(getCursorClasses(editor), ['ParticipantCursor--site-2'])
+
+    binding.updateSelectionsForSiteId(1, {1: {range: Range([0, 0], [0, 0])}})
+    assert.deepEqual(getCursorClasses(editor), ['ParticipantCursor--site-2', 'ParticipantCursor--site-1'])
+
+    binding.updateSelectionsForSiteId(3, {1: {range: Range([0, 0], [0, 0])}})
+    assert.deepEqual(getCursorClasses(editor), ['ParticipantCursor--site-2', 'ParticipantCursor--site-1', 'ParticipantCursor--site-3'])
+
+    binding.clearSelectionsForSiteId(1)
+    assert.deepEqual(getCursorClasses(editor), ['ParticipantCursor--site-2', 'ParticipantCursor--site-3'])
+
+    binding.dispose()
+    assert.deepEqual(getCursorClasses(editor), [])
+  })
+
   function getCursorDecoratedRanges (editor) {
     const {decorationManager} = editor
     const decorationsByMarker = decorationManager.decorationPropertiesByMarkerForScreenRowRange(0, Infinity)
@@ -362,13 +384,32 @@ suite('EditorBinding', function () {
       return {head: m.getHeadBufferPosition(), tail: m.getTailBufferPosition()}
     })
   }
+
+  function getCursorClasses (editor) {
+    const {decorationManager} = editor
+    const decorationsByMarker = decorationManager.decorationPropertiesByMarkerForScreenRowRange(0, Infinity)
+    const cursorDecorations = []
+    for (const [marker, decorations] of decorationsByMarker) {
+      let className = ''
+      for (const decoration of decorations) {
+        if (decoration.type === 'cursor' && decoration.class) {
+          className += ' ' + decoration.class
+        }
+      }
+
+      if (className) cursorDecorations.push(className.slice(1))
+    }
+
+    return cursorDecorations
+  }
 })
 
 class FakeEditorProxy {
-  constructor (delegate) {
+  constructor (delegate, {siteId} = {}) {
     this.delegate = delegate
     this.bufferProxy = {uri: 'fake-buffer-proxy-uri'}
     this.selections = {}
+    this.siteId = (siteId == null) ? 1 : siteId
   }
 
   updateSelections (selectionUpdates) {


### PR DESCRIPTION
Since themes only provide 5 variables, we will provide 10 additional variants generated using the built-in `spin` function in LESS. This is how the palette looks on the `one-light-ui` and `one-dark-ui` backgrounds:

<p align="center">
  <img src="https://user-images.githubusercontent.com/482957/31618716-04918736-b293-11e7-96b3-92d70fd463aa.png" />
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/482957/31618717-04b5da78-b293-11e7-94aa-6423cb2d86ac.jpg" />
</p>

And this is a screenshot of using the first 5 cursor colors in Atom with both themes:
![screen shot 2017-10-16 at 16 38 36](https://user-images.githubusercontent.com/482957/31618849-5aa4f496-b293-11e7-854c-4497be786363.png)

![screen shot 2017-10-16 at 16 38 53](https://user-images.githubusercontent.com/482957/31618848-5a86d3e4-b293-11e7-9737-3ad3c7975814.png)

Starting with the 16th participant, we will start styling new cursors using the default cursor color.

/cc: @nathansobo @jasonrudolph 