### PR TITLE
Small layout changes to the popup dialog

### DIFF
--- a/lib/sign-in-component.js
+++ b/lib/sign-in-component.js
@@ -55,7 +55,7 @@ class SignInComponent {
           {
             ref: 'loginButton',
             type: 'button',
-            className: 'btn btn-primary inline-block-tight',
+            className: 'btn btn-primary btn-sm inline-block-tight',
             onClick: this.signIn
           },
           'Sign in'

--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -183,6 +183,7 @@
   padding: @component-padding;
 
   atom-text-editor {
+    font-size: 12px !important;
     margin-bottom: @component-padding;
     text-align: left;
   }


### PR DESCRIPTION
Hi! I'm getting familiar with the real-time package codebase and am proposing a minor change to the "Sign in" dialog!

Here's what it looked like before:

<img width="314" alt="screen shot 2017-10-17 at 1 47 23 pm" src="https://user-images.githubusercontent.com/1174461/31690078-76595b7e-b346-11e7-9429-59103e594c9b.png">

<img width="312" alt="screen shot 2017-10-17 at 1 47 52 pm" src="https://user-images.githubusercontent.com/1174461/31690085-7b299aba-b346-11e7-928c-587821c30c31.png">

The overall rational behind these changes comes from our sign in screens for dotcom:

<img src="https://user-images.githubusercontent.com/1174461/31690120-9682068a-b346-11e7-9cb7-f3f68594b27b.png" width="350" />

The changes are:

- Moved the github mark to above the title
- Aligned the language to the website (`s/log in/sign in/g`)
- Decreased the font size of the title since it's displayed in a small space

There are a couple of things I'm wondering:

It would be nice if the token text field could be a smaller font size. I tried using an input instead, but wasn't able to get a handful of things working (for example: it would let me use the backspace key and the styles would be off.) If things look good, I can timebox another 15-30 minutes on the input field then 🖐 for help! 🙇 