### PR TITLE
Implement BufferBinding.serialize

### DIFF
--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -106,4 +106,18 @@ class BufferBinding {
   }
 
   enforceUndoStackSizeLimit () {}
+
+  serialize (options) {
+    return this.serializeUsingDefaultHistoryProviderFormat(options)
+  }
+
+  serializeUsingDefaultHistoryProviderFormat (options) {
+    const {maxUndoEntries} = this.buffer
+    this.buffer.restoreDefaultHistoryProvider(this.bufferProxy.getHistory(maxUndoEntries))
+    const serializedDefaultHistoryProvider = this.buffer.historyProvider.serialize(options)
+
+    this.buffer.setHistoryProvider(this)
+
+    return serializedDefaultHistoryProvider
+  }
 }

--- a/test/real-time-package.test.js
+++ b/test/real-time-package.test.js
@@ -614,6 +614,37 @@ suite('RealTimePackage', function () {
     assert.equal(editor.getText(), 'hello world!')
   })
 
+  test('history serialization', async () => {
+    let serializedEnvironment
+
+    {
+      const env = buildAtomEnvironment()
+      const pack = await buildPackage(env)
+      await pack.sharePortal()
+
+      const editor = await env.workspace.open()
+      editor.insertText('a')
+      editor.insertText('b')
+      editor.insertText('c')
+
+      serializedEnvironment = env.serialize({isUnloading: true})
+    }
+
+    {
+      const env = buildAtomEnvironment()
+      await env.deserialize(serializedEnvironment)
+
+      const editor = env.workspace.getActiveTextEditor()
+      assert.equal(editor.getText(), 'abc')
+
+      editor.undo()
+      assert.equal(editor.getText(), 'ab')
+
+      editor.redo()
+      assert.equal(editor.getText(), 'abc')
+    }
+  })
+
   test('splitting editors', async () => {
     const hostEnv = buildAtomEnvironment()
     const hostPackage = await buildPackage(hostEnv)


### PR DESCRIPTION
Fixes #96 

This new method will use the default history provider to serialize the history of the replicated buffer, so that when Atom reloads it can deserialize the buffer as a normal `TextBuffer` using `DefaultHistoryProvider`. 

This will have the effect of retaining the replicated buffer's undo/redo stack upon reload.

🍐'd with @jasonrudolph 

/cc: @nathansobo 