### PR TITLE
Enhance EmptyPortalPaneItem to show host's username

### DIFF
--- a/lib/empty-portal-pane-item.js
+++ b/lib/empty-portal-pane-item.js
@@ -2,7 +2,8 @@ const {Emitter} = require('atom')
 
 module.exports =
 class EmptyPortalPaneItem {
-  constructor () {
+  constructor ({hostIdentity}) {
+    this.hostLogin = `@${hostIdentity.login}`
     this.emitter = new Emitter()
     this.element = document.createElement('div')
     this.element.tabIndex = -1
@@ -12,11 +13,9 @@ class EmptyPortalPaneItem {
     this.element.style.top = '50%'
     this.element.style.fontSize = '24px'
     this.element.style.textAlign = 'center'
-    // TODO: Replace "host" with the person's first name (or @username) once we
-    // implement authentication.
     this.element.innerHTML = `
-      Your host is doing something else right now.<br/>
-      Sharing will resume once the host is editing again.
+      ${this.hostLogin} is doing something else right now.<br/>
+      Sharing will resume once ${this.hostLogin} is editing again.
     `
   }
 
@@ -31,7 +30,7 @@ class EmptyPortalPaneItem {
   }
 
   getTitle () {
-    return 'Portal: No Active File'
+    return `${this.hostLogin}: No Active File`
   }
 
   destroy () {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -15,7 +15,6 @@ class GuestPortalBinding {
     this.emitDidDispose = didDispose
     this.activePaneItem = null
     this.activeEditorBinding = null
-    this.emptyPortalItem = new EmptyPortalPaneItem()
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
     this.emitter = new Emitter()
@@ -38,7 +37,7 @@ class GuestPortalBinding {
   dispose () {
     if (this.activePaneItemDestroySubscription) this.activePaneItemDestroySubscription.dispose()
     if (this.activePaneItem) this.activePaneItem.destroy()
-    this.emptyPortalItem.destroy()
+    if (this.emptyPortalItem) this.emptyPortalItem.destroy()
     this.emitDidDispose()
   }
 
@@ -59,7 +58,7 @@ class GuestPortalBinding {
   async setActiveEditorProxy (editorProxy) {
     this.lastSetActiveEditorProxyPromise = this.lastSetActiveEditorProxyPromise.then(async () => {
       if (editorProxy == null) {
-        await this.replaceActivePaneItem(this.emptyPortalItem)
+        await this.replaceActivePaneItem(this.getEmptyPortalPaneItem())
       } else {
         const {bufferProxy} = editorProxy
         let editor
@@ -175,6 +174,15 @@ class GuestPortalBinding {
 
   getActivePaneItem () {
     return this.newActivePaneItem ? this.newActivePaneItem : this.activePaneItem
+  }
+
+  getEmptyPortalPaneItem () {
+    if (this.emptyPortalItem == null) {
+      this.emptyPortalItem = new EmptyPortalPaneItem({
+        hostIdentity: this.portal.getSiteIdentity(1)
+      })
+    }
+    return this.emptyPortalItem
   }
 
   onDidChange (callback) {

--- a/test/empty-portal-pane-item.test.js
+++ b/test/empty-portal-pane-item.test.js
@@ -3,12 +3,18 @@ const EmptyPortalPaneItem = require('../lib/empty-portal-pane-item')
 
 suite('EmptyPortalPaneItem', () => {
   test('copy()', () => {
-    const paneItem = new EmptyPortalPaneItem()
+    const paneItem = new EmptyPortalPaneItem({hostIdentity: {login: 'host'}})
     assert.equal(paneItem.copy(), null)
   })
 
   test('serialize()', () => {
-    const paneItem = new EmptyPortalPaneItem()
+    const paneItem = new EmptyPortalPaneItem({hostIdentity: {login: 'host'}})
     assert.equal(paneItem.serialize(), null)
+  })
+
+  test('getTitle()', () => {
+    const hostIdentity = {login: 'some-host'}
+    const paneItem = new EmptyPortalPaneItem({hostIdentity})
+    assert.equal(paneItem.getTitle(), '@some-host: No Active File')
   })
 })

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -82,7 +82,7 @@ suite('GuestPortalBinding', () => {
 
     assert.deepEqual(
       activePaneItemChangeEvents.map((i) => i.getTitle()),
-      ['@some-host: uri-1', '@some-host: uri-2', 'Portal: No Active File', '@some-host: uri-3']
+      ['@some-host: uri-1', '@some-host: uri-2', '@some-host: No Active File', '@some-host: uri-3']
     )
     assert.deepEqual(
       atomEnv.workspace.getPaneItems().map((i) => i.getTitle()),


### PR DESCRIPTION
This PR addresses the following item from [the roadmap](https://github.com/github/atom-log/blob/76a0bf4b4b734a9c5095be60dda8eefc20065d85/real-time-collaboration/portals-roadmap.md#milestone-5-pre-launch-refinements): 

> - [x] Tweak `EmptyPortalPaneItem` to show host's username

### Before and After

![screenshot](https://user-images.githubusercontent.com/2988/31830644-daa5b72c-b58e-11e7-8590-6a5e0e8e227c.png)
