### PR TITLE
Eliminate redundant onDidAddPaneItem events for guest editors

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -17,6 +17,7 @@ class GuestPortalBinding {
     this.activeEditorBinding = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
+    this.addedPaneItems = new WeakSet()
     this.emitter = new Emitter()
     this.lastSetActiveEditorProxyPromise = Promise.resolve()
   }
@@ -160,11 +161,12 @@ class GuestPortalBinding {
     if (this.activePaneItem) {
       const pane = this.workspace.paneForItem(this.activePaneItem)
       const index = pane.getItems().indexOf(this.activePaneItem)
-      pane.addItem(newActivePaneItem, {index})
+      pane.addItem(newActivePaneItem, {index, moved: this.addedPaneItems.has(newActivePaneItem)})
       pane.removeItem(this.activePaneItem)
     } else {
       await this.workspace.open(newActivePaneItem)
     }
+    this.addedPaneItems.add(newActivePaneItem)
 
     this.activePaneItem = this.newActivePaneItem
     if (this.activePaneItemDestroySubscription) this.activePaneItemDestroySubscription.dispose()

--- a/test/real-time-package.test.js
+++ b/test/real-time-package.test.js
@@ -58,6 +58,14 @@ suite('RealTimePackage', function () {
     const hostPackage = await buildPackage(hostEnv)
     const guestEnv = buildAtomEnvironment()
     const guestPackage = await buildPackage(guestEnv)
+
+    // Ensure we don't emit an add event more than once for a given guest editor
+    const observedGuestItems = new Set()
+    guestEnv.workspace.onDidAddPaneItem(({item}) => {
+      assert(!observedGuestItems.has(item))
+      observedGuestItems.add(item)
+    })
+
     const portalId = (await hostPackage.sharePortal()).id
 
     guestPackage.joinPortal(portalId)
@@ -94,6 +102,8 @@ suite('RealTimePackage', function () {
     assert.equal(guestEditor1.getText(), 'const hello = "world"')
     assert(!guestEditor1.isModified())
     await condition(() => deepEqual(getCursorDecoratedRanges(hostEditor1), getCursorDecoratedRanges(guestEditor1)))
+
+    assert.equal(observedGuestItems.size, 2)
   })
 
   test('host joining another portal as a guest', async () => {


### PR DESCRIPTION
Closes #118

We're currently using the private `removeItem` method to remove guest editors from the workspace without destroying them. This allows us to keep a 1:1 correspondence between an editor on the host and an editor on each guest, and we can swap the correct editors back into the guest's workspace when the host switches to the editor it corresponds to in their workspace.

An unfortunate side effect of removing editors without destroying them is that when we added the editors back to the workspace, we were firing the same events that we would have fired if these editors were completely new workspace, which caused several packages to make redundant subscriptions since we've never before seen the same editor getting added to the workspace twice.

This PR continues the use of private APIs by passing the undocumented `moved: true` option when adding an editor we have already added once. This is used by the workspace internally to prevent redundant add events when moving an item between panes. We really should enhance the workspace APIs to provide official support for removing an item from the workspace without destroying it, although it will be tricky to decide what to do about these notification events when an item is added a second time.

/cc @as-cii 