### PR TITLE
Show spinner when toggling sharing on

### DIFF
--- a/lib/host-portal-binding-component.js
+++ b/lib/host-portal-binding-component.js
@@ -43,7 +43,13 @@ class HostPortalBindingComponent {
           $.div({className: 'HostPortalComponent-share-toggle'},
             $.label(null,
               'Share ',
-              this.props.creatingPortal ? this.renderCreatingPortalSpinner() : this.renderShareToggle()
+              $.input({
+                ref: 'toggleShareCheckbox',
+                className: 'input-toggle',
+                type: 'checkbox',
+                onClick: this.toggleShare,
+                checked: this.isSharing() || this.props.creatingPortal
+              })
             )
           )
         )
@@ -51,28 +57,17 @@ class HostPortalBindingComponent {
     )
   }
 
-  renderShareToggle () {
-    return $.input({
-      ref: 'toggleShareCheckbox',
-      className: 'input-toggle',
-      type: 'checkbox',
-      onClick: this.toggleShare,
-      checked: this.isSharing()
-    })
-  }
-
-  renderCreatingPortalSpinner () {
-    return $.span({ref: 'creatingPortalSpinner', className: 'loading loading-spinner-tiny inline-block'})
-  }
-
   renderConnectionInfo () {
-    if (this.isSharing()) {
-      const copyButtonText = this.props.showCopiedConfirmation ? 'Copied' : 'Copy'
+    const {creatingPortal, showCopiedConfirmation} = this.props
+    const statusClassName = creatingPortal ? 'creating-portal' : ''
+    if (creatingPortal || this.isSharing()) {
+      const copyButtonText = showCopiedConfirmation ? 'Copied' : 'Copy'
       return $.div({className: 'HostPortalComponent-connection-info'},
-        $.div({className: 'HostPortalComponent-connection-info-heading'},
+        creatingPortal ? this.renderCreatingPortalSpinner() : null,
+        $.div({className: 'HostPortalComponent-connection-info-heading ' + statusClassName},
           $.h1(null, 'Invite collaborators to join your portal with this ID')
         ),
-        $.div({className: 'HostPortalComponent-connection-info-portal-id'},
+        $.div({className: 'HostPortalComponent-connection-info-portal-id ' + statusClassName},
           $.input({className: 'input-text host-id-input', type: 'text', disabled: true, value: this.getPortalId()}),
           $.span({className: 'btn btn-xs', onClick: this.copyPortalIdToClipboard}, copyButtonText)
         )
@@ -80,6 +75,10 @@ class HostPortalBindingComponent {
     } else {
       return null
     }
+  }
+
+  renderCreatingPortalSpinner () {
+    return $.span({ref: 'creatingPortalSpinner', className: 'HostPortalComponent-connection-info-spinner loading loading-spinner-tiny'})
   }
 
   async toggleShare () {

--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -135,8 +135,13 @@
     flex-direction: column;
     align-items: stretch;
     padding: @component-padding @component-padding (@component-padding / 2);
+    position: relative;
 
     &-heading {
+      &.creating-portal {
+        visibility: hidden;
+      }
+
       h1 {
         margin-top: 0;
         margin-bottom: @component-padding / 2;
@@ -155,6 +160,10 @@
       flex-direction: row;
       margin-bottom: 5px;
 
+      &.creating-portal {
+        visibility: hidden;
+      }
+
       .input-text {
         display: flex;
         flex: auto;
@@ -164,6 +173,13 @@
         margin-left: @component-padding / 2;
         flex: none;
       }
+    }
+
+    &-spinner {
+      position: absolute !important;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
     }
   }
 

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -57,11 +57,10 @@ suite('PortalListComponent', function () {
     // Toggle sharing on.
     hostPortalBindingComponent.toggleShare()
     await condition(() => (
-      !hostPortalBindingComponent.refs.toggleShareCheckbox &&
+      hostPortalBindingComponent.refs.toggleShareCheckbox.checked &&
       hostPortalBindingComponent.refs.creatingPortalSpinner
     ))
     await condition(() => (
-      hostPortalBindingComponent.refs.toggleShareCheckbox &&
       hostPortalBindingComponent.refs.toggleShareCheckbox.checked &&
       !hostPortalBindingComponent.refs.creatingPortalSpinner
     ))


### PR DESCRIPTION
This PR aims to address the following task from https://github.com/atom/real-time/issues/124:

> - [x] Show spinner (or other indication of work in progress) when enabling sharing. (Currently, if it takes you a while to receive the response from the server, you can be left wondering whether anything is happening. [demo])

### TODO

- [x] Update component to render spinner while waiting for host portal to be created
- [x] Apply CSS for pleasant rendering ✨  


