### PR TITLE
Depend on the keytar module bundled with Atom

### DIFF
--- a/lib/credential-cache.js
+++ b/lib/credential-cache.js
@@ -1,5 +1,5 @@
 const {execFile} = require('child_process')
-const keytar = require('keytar')
+const path = require('path')
 
 const SERVICE_NAME = 'atom-tachyon'
 
@@ -35,12 +35,22 @@ class CredentialCache {
   }
 }
 
+let keytar
+function getKeytar () {
+  if (!keytar) {
+    const bundledKeytarPath = path.join(atom.getLoadSettings().resourcePath, 'node_modules', 'keytar')
+    keytar = require(bundledKeytarPath)
+  }
+
+  return keytar
+}
+
 class KeytarStrategy {
   static async isValid () {
     try {
-      await keytar.setPassword('atom-test-service', 'test-key', 'test-value')
-      const value = await keytar.getPassword('atom-test-service', 'test-key')
-      keytar.deletePassword('atom-test-service', 'test-key')
+      await getKeytar().setPassword('atom-test-service', 'test-key', 'test-value')
+      const value = await getKeytar().getPassword('atom-test-service', 'test-key')
+      getKeytar().deletePassword('atom-test-service', 'test-key')
       return value === 'test-value'
     } catch (err) {
       return false
@@ -48,15 +58,15 @@ class KeytarStrategy {
   }
 
   get (service, key) {
-    return keytar.getPassword(service, key)
+    return getKeytar().getPassword(service, key)
   }
 
   set (service, key, value) {
-    return keytar.setPassword(service, key, value)
+    return getKeytar().setPassword(service, key, value)
   }
 
   delete (service, key) {
-    return keytar.deletePassword(service, key)
+    return getKeytar().deletePassword(service, key)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.20.2",
-    "etch": "^0.12.6",
-    "keytar": "^4.0.4"
+    "etch": "^0.12.6"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
To avoid the issues that users often encounter (especially on Windows) when installing a package that contains native code, we're choosing to depend on the keytar module that's bundled with Atom. This is admittedly a bit of a hack, but it feels like the pragmatic choice for now given the effort that would be required to set up something like node-pre-gyp to distribute platform-specific builds of keytar.

Closes https://github.com/atom/real-time/issues/111.