### PR TITLE
Fix contrast of "Join a portal" link

### DIFF
--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -246,7 +246,7 @@
   }
 
   label:hover {
-    color: darken(@text-color-subtle, 30%);
+    color: @text-color-selected;
     cursor: pointer;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/141

### Before

![demo](https://user-images.githubusercontent.com/2988/32077209-9386467c-ba70-11e7-99f0-d32bbdbd20c7.gif)

### After

![demo-3](https://user-images.githubusercontent.com/2988/32125963-61b41ef4-bb3c-11e7-94af-65a5b3fdd67e.gif)

I also verified that it still looks good in a light theme:

![demo-2](https://user-images.githubusercontent.com/2988/32125983-7bed84f4-bb3c-11e7-8bfe-f1f90a991cb3.gif)

It also looks good in our most-downloaded UI theme:

![demo](https://user-images.githubusercontent.com/2988/32125991-88ff1f68-bb3c-11e7-8a96-d5032770079e.gif)

