### PR TITLE
Fix poor rendering of portal sharing instructions in popular Material UI theme

### DIFF
--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -25,7 +25,7 @@
   user-select: none;
 
   &.tooltip {
-    width: 300px;
+    width: 315px;
     padding-left: @component-padding;
     padding-right: @component-padding;
     box-sizing: border-box;


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/143

### Before

<img width="317" alt="screen shot 2017-10-27 at 5 37 32 pm" src="https://user-images.githubusercontent.com/2988/32126322-fd2ac5b2-bb3d-11e7-96da-70d39ee65748.png">

### After

<img width="330" alt="screen shot 2017-10-27 at 5 37 11 pm" src="https://user-images.githubusercontent.com/2988/32126321-fd15286a-bb3d-11e7-8491-2208dbd04475.png">

---

Note: I also confirmed that it still looks good in other commonly-used themes (e.g., one light UI):

<img width="332" alt="screen shot 2017-10-27 at 5 37 47 pm" src="https://user-images.githubusercontent.com/2988/32126323-fd3fcc78-bb3d-11e7-93c6-4f2602654684.png">


