### PR TITLE
Fix ability to use package with the popular Native UI theme

### DIFF
--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -3,8 +3,7 @@ const PopoverComponent = require('./popover-component')
 module.exports =
 class PortalStatusBarIndicator {
   constructor (props) {
-    this.element = document.createElement('a')
-    this.element.classList.add('PortalStatusBarIndicator', 'icon', 'inline-block')
+    this.element = buildElement()
     this.popoverComponent = new PopoverComponent(props)
     this.tooltip = props.tooltipManager.add(
       this.element,
@@ -42,4 +41,15 @@ class PortalStatusBarIndicator {
     this.tooltip.dispose()
     this.subscriptions.dispose()
   }
+}
+
+function buildElement () {
+  const anchor = document.createElement('a')
+  anchor.classList.add('PortalStatusBarIndicator', 'inline-block')
+
+  const icon = document.createElement('span')
+  icon.classList.add('icon', 'icon-radio-tower')
+  anchor.appendChild(icon)
+
+  return anchor
 }

--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -5,8 +5,6 @@
 @join-leave-button-width: 50px;
 
 .PortalStatusBarIndicator {
-  .octicon(radio-tower);
-
   // Remove margin on the icon since there is no text that follows
   &&&:before {
     margin-right: 0;


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/144

Prior to this change, we were rendering the status bar icon as an empty anchor tag. That works fine in most UI themes, but it doesn't work in the popular [Native UI](https://atom.io/themes/native-ui) theme. By adding a span as a child of the anchor tag, the Native UI theme successfully renders the status bar icon, and other themes continue to render the status bar icon just fine as well.

### Before

<img width="726" alt="screen shot 2017-10-27 at 6 05 36 pm" src="https://user-images.githubusercontent.com/2988/32127445-eb2ffaba-bb44-11e7-8548-6157b658147b.png">

### After

<img width="721" alt="screen shot 2017-10-27 at 6 05 10 pm" src="https://user-images.githubusercontent.com/2988/32127449-f6297554-bb44-11e7-877b-61a96e5da9b2.png">

---

Note that other themes should not be negatively affected by this change. For example, using this branch in conjunction with the One Dark UI theme, the status bar renders just the same as it did before:

<img width="773" alt="screen shot 2017-10-27 at 6 06 34 pm" src="https://user-images.githubusercontent.com/2988/32127446-eb3e1b36-bb44-11e7-8539-3e5ef140549e.png">
