### PR TITLE
Position popover properly after sign-in

### DIFF
--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -89,7 +89,7 @@
     margin: @component-padding / 2;
 
     img {
-      width: 22px;
+      height: 22px;
       border-radius: 50%
     }
   }
@@ -98,7 +98,7 @@
     margin-left: 0;
 
     img {
-      width: 28px;
+      height: 28px;
     }
   }
 }


### PR DESCRIPTION
Fixes #139 

Prior to this change, we would render the HostPortalComponent with a height that is determined by the height of the toggle switch, and then the host avatar `img` would get rendered, and that would increase the height of HostPortalComponent. By setting the height of the host avatar `img` in CSS, the `img`'s height will remain constant when the `img` element is first rendered _and_ after the avatar is fetched from the GitHub CDN and rendered inside the popover. 😅

### Before

![before](https://user-images.githubusercontent.com/2988/32074190-a5257f2e-ba66-11e7-9c08-8e39bf338cb0.gif)

### After

![after](https://user-images.githubusercontent.com/2988/32191950-26cd9e24-bd89-11e7-838b-21c0e583c2d9.gif)
