### PR TITLE
Improve error message shown when failing to join portal

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -118,7 +118,9 @@ class GuestPortalBinding {
       description = 'No portal exists with that ID. Please ask your host to provide you with their current portal ID.'
     } else {
       message = 'Failed to join portal'
-      description = `Attempting to join portal ${this.portalId} failed with error: <code>${error.message}</code>`
+      description =
+        `Attempting to join portal ${this.portalId} failed with error: <code>${error.message}</code>\n\n` +
+        'Please wait a few moments and try again.'
     }
     this.notificationManager.addError(message, {
       description,


### PR DESCRIPTION
\#132 describes an issue where a user sometimes encounters an error when attempting to join a portal:

![32025116-d4e17124-b993-11e7-8f50-624290e29943](https://user-images.githubusercontent.com/2988/32194109-c7e32abc-bd8f-11e7-8d06-822bd8823f1e.png)

\#132 goes on to explain that, "if you try a 2nd time everything works fine."

It would be nice to prevent this error from happening entirely. In the meantime, we can improve the error message to not only state that a failure happened, but also suggest a solution. [1]

With the changes in this PR, we'll explain the error and encourage the user to try again:

![screen shot 2017-10-30 at 4 37 24 pm](https://user-images.githubusercontent.com/2988/32194425-bf315d7a-bd90-11e7-9a11-7385ca6d5fd4.png)

---

[1] Shout-out to @lee-dohm's comment in https://github.com/github/atom.io/pull/1109#issuecomment-293082061 re: writing copy for error messages:

> From the [.NET Framework Design Guidelines](https://www.amazon.com/Framework-Design-Guidelines-Conventions-Development-ebook/dp/B0017SWPNO/):
>
>> In my own programming, I dearly love error messages that say what I did wrong *and* how to fix it. All too often, all I get is the former, when all I really care about is the latter.
>
> *(Emphasis mine)*
