### PR TITLE
Use button element instead of span element for "Copy" button

### DIFF
--- a/lib/host-portal-binding-component.js
+++ b/lib/host-portal-binding-component.js
@@ -69,7 +69,7 @@ class HostPortalBindingComponent {
         ),
         $.div({className: 'HostPortalComponent-connection-info-portal-id ' + statusClassName},
           $.input({className: 'input-text host-id-input', type: 'text', disabled: true, value: this.getPortalId()}),
-          $.span({className: 'btn btn-xs', onClick: this.copyPortalIdToClipboard}, copyButtonText)
+          $.button({className: 'btn btn-xs', onClick: this.copyPortalIdToClipboard}, copyButtonText)
         )
       )
     } else {


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/142

## Demo

[Isotope](https://atom.io/themes/isotope-ui) is the 6th most starred UI theme and the 11th most downloaded UI theme. Prior to this PR, the "leave" and "join" buttons rendered correctly in the Isotope theme, but the "copy" button rendered poorly:

### Before

![before](https://user-images.githubusercontent.com/2988/32195008-663d5ce4-bd92-11e7-8249-96a7e7e2d3a8.png)

### After

![after](https://user-images.githubusercontent.com/2988/32195007-66291c20-bd92-11e7-917d-519d31f0416d.png)

---

Note: I also verified that this change doesn't adversely affect other themes. For example, this PR has no discernible effect on the One Light UI theme:

![screen shot 2017-10-30 at 4 46 09 pm](https://user-images.githubusercontent.com/2988/32195009-6655eb4c-bd92-11e7-8510-309956120400.png)
