### PR TITLE
Fix contrast of portal ID in Nord Atom UI theme

### DIFF
--- a/styles/real-time.less
+++ b/styles/real-time.less
@@ -184,6 +184,7 @@
   .host-id-input {
     font-family: @font-family-monospace;
     font-size: 80%;
+    color: @text-color;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/atom/real-time/issues/146

[Nord Atom UI](https://atom.io/themes/nord-atom-ui) is the 7th most starred UI theme and the 12th most downloaded UI theme. Prior to this change, the portal ID rendered with a poor contrast in this theme. With this change in place, the portal ID renders with a good contrast in the Nord Atom UI theme and continues to render nicely in the other popular themes.

### Nord Atom UI: Before and After

![before](https://user-images.githubusercontent.com/2988/32196103-e9475100-bd95-11e7-8f4f-35b040d8160b.png)

![after](https://user-images.githubusercontent.com/2988/32196104-eb28c09e-bd95-11e7-9d00-81d53cde5bc8.png)

### One Dark UI: Before and After

![before](https://user-images.githubusercontent.com/2988/32196161-2595634a-bd96-11e7-8b83-d388de6a726b.png)

![after](https://user-images.githubusercontent.com/2988/32196160-2580e30c-bd96-11e7-9ce6-28a9574ab985.png)

### One Light UI: Before and After

![before](https://user-images.githubusercontent.com/2988/32196218-4f26f930-bd96-11e7-941a-ff174299b13a.png)

![after](https://user-images.githubusercontent.com/2988/32196217-4f167b32-bd96-11e7-83da-32da17ec867b.png)
