### PR TITLE
Use an approximation to determine the visibility of a position

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -251,16 +251,17 @@ class EditorBinding {
     const {element} = this.editor
     if (!document.contains(element)) return
 
-    const screenPosition = this.editor.screenPositionForBufferPosition(bufferPosition)
-    const pixelPosition = element.pixelPositionForScreenPosition(screenPosition)
+    const {row, column} = this.editor.screenPositionForBufferPosition(bufferPosition)
+    const top = element.component.pixelPositionAfterBlocksForRow(row)
+    const left = column * this.editor.getDefaultCharWidth()
 
-    if (pixelPosition.top < element.getScrollTop()) {
+    if (top < element.getScrollTop()) {
       return 'upward'
-    } else if (pixelPosition.top >= element.getScrollBottom()) {
+    } else if (top >= element.getScrollBottom()) {
       return 'downward'
-    } else if (pixelPosition.left < element.getScrollLeft()) {
+    } else if (left < element.getScrollLeft()) {
       return 'leftward'
-    } else if (pixelPosition.left >= element.getScrollRight()) {
+    } else if (left >= element.getScrollRight()) {
       return 'rightward'
     } else {
       return 'inside'

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -397,6 +397,9 @@ suite('EditorBinding', function () {
     assert(!binding.isPositionVisible({row: 0, column: 9}))
     assert(!binding.isPositionVisible({row: 6, column: 0}))
 
+    // Ensure text is rendered, so that we can scroll down/right.
+    await editor.component.getNextUpdatePromise()
+
     setEditorScrollTopInLines(editor, 5)
     setEditorScrollLeftInChars(editor, 5)
 


### PR DESCRIPTION
This will allow us to avoid the cost of calling `pixelPositionForScreenPosition` on the editor element, which causes a re-render of the entire editor and can be pretty bad in terms of performance.

The tradeoff here is that we could return wrong values when a non-monospace font is used, or when a line has many non-monospaced ligatures. We think this is the right choice, though, considering its performance benefits.

/cc: @nathansobo @jasonrudolph 