### PR TITLE
Show link icon next to the person you are explicitly following

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -222,7 +222,7 @@ class EditorBinding {
     const aboveViewportSiteIds = []
     const insideViewportSiteIds = []
     const outsideViewportSiteIds = []
-    const leaderSiteId = this.getLeaderSiteId()
+    const followedSiteId = this.editorProxy.getFollowedSiteId()
 
     for (let siteId in positionsBySiteId) {
       siteId = parseInt(siteId)
@@ -242,9 +242,9 @@ class EditorBinding {
       }
     }
 
-    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, leaderSiteId})
-    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, leaderSiteId})
-    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, leaderSiteId})
+    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
+    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
+    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})
     this.positionsBySiteId = positionsBySiteId
   }
 
@@ -296,17 +296,11 @@ class EditorBinding {
   }
 
   toggleFollowingForSiteId (siteId) {
-    if (siteId === this.getLeaderSiteId()) {
+    if (siteId === this.editorProxy.getFollowedSiteId()) {
       this.editorProxy.unfollow()
     } else {
       this.editorProxy.follow(siteId)
     }
-  }
-
-  getLeaderSiteId () {
-    return this.editorProxy.resolveFollowState() === FollowState.DISCONNECTED
-      ? null
-      : this.editorProxy.resolveLeaderSiteId()
   }
 }
 

--- a/lib/site-positions-component.js
+++ b/lib/site-positions-component.js
@@ -27,11 +27,11 @@ class SitePositionsComponent {
   }
 
   renderSite (siteId) {
-    const {portal, leaderSiteId} = this.props
+    const {portal, followedSiteId} = this.props
     const {login} = portal.getSiteIdentity(siteId)
 
     return $.div({className: 'SitePositionsComponent-site'},
-      (leaderSiteId === siteId) ? $.div({className: 'icon icon-link'}) : null,
+      (followedSiteId === siteId) ? $.div({className: 'icon icon-link'}) : null,
       $.img({
         src: getAvatarURL(login, 80),
         onClick: () => this.props.onSelectSiteId(siteId)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.22.2",
+    "@atom/real-time-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/real-time-client/tarball/v0.23.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -410,11 +410,11 @@ suite('EditorBinding', function () {
 
     // Selecting a site will follow them.
     outsideViewportSitePositionsComponent.props.onSelectSiteId(2)
-    assert.equal(editorProxy.resolveLeaderSiteId(), 2)
+    assert.equal(editorProxy.getFollowedSiteId(), 2)
 
     // Selecting the same site again will unfollow them.
     outsideViewportSitePositionsComponent.props.onSelectSiteId(2)
-    assert(!editorProxy.resolveLeaderSiteId())
+    assert.equal(editorProxy.getFollowedSiteId(), null)
   })
 
   test('isPositionVisible(position)', async () => {
@@ -552,21 +552,21 @@ class FakeEditorProxy {
   }
 
   follow (siteId) {
-    this.leaderSiteId = siteId
+    this.followedSiteId = siteId
     this.followState = FollowState.RETRACTED
   }
 
   unfollow () {
-    this.leaderSiteId = null
+    this.followedSiteId = null
     this.followState = FollowState.DISCONNECTED
   }
 
-  resolveLeaderSiteId () {
-    return this.leaderSiteId
-  }
-
-  resolveFollowState() {
-    return this.followState
+  getFollowedSiteId () {
+    if (this.followState === FollowState.DISCONNECTED) {
+      return null
+    } else {
+      return this.followedSiteId
+    }
   }
 }
 


### PR DESCRIPTION
...and not the person that you are implicitly following. For instance, if the local site follows B, and B follows C, we will show the link icon next to B.

This addresses the second part of #155: 

> * [ ] Show the link icon next to the person that you are explicitly following, not the person that you are implicitly following

🍐'd with @jasonrudolph.

/cc: @nathansobo 