### PR TITLE
Use teletype.atom.io and api.teletype.atom.io

### DIFF
--- a/lib/sign-in-component.js
+++ b/lib/sign-in-component.js
@@ -44,7 +44,7 @@ class SignInComponent {
     return $.div(null,
       $.p(null,
         'Visit ',
-        $.a({href: 'https://tachyon.atom.io/login', className: 'text-info'}, 'tachyon.atom.io/login'),
+        $.a({href: 'https://teletype.atom.io/login', className: 'text-info'}, 'teletype.atom.io/login'),
         ' to generate an authentication token and paste it below:'
       ),
       this.renderErrorMessage(),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "title": "API server base URL",
       "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
       "type": "string",
-      "default": "https://api.tachyon.atom.io",
+      "default": "https://api.teletype.atom.io",
       "order": 1
     },
     "pusherKey": {


### PR DESCRIPTION
Use https://teletype.atom.io for obtaining an OAuth token, and use https://api.teletype.atom.io to access the REST API.