### PR TITLE
Add menu commands for sharing and joining a portal

### DIFF
--- a/menus/teletype.json
+++ b/menus/teletype.json
@@ -1,0 +1,22 @@
+{
+  "menu": [
+    {
+      "label": "Packages",
+      "submenu": [
+        {
+          "label": "Teletype",
+          "submenu": [
+            {
+              "label": "Share Portal",
+              "command": "teletype:share-portal"
+            },
+            {
+              "label": "Join Portal",
+              "command": "teletype:join-portal"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds another avenue of discoverability/accessibility by providing menu commands for sharing and joining a portal. In just the same way that the  commands in the command palette reveal the popover, the menu commands do as well:

![2017-11-08 15_09_42](https://user-images.githubusercontent.com/2988/32571867-e5277458-c496-11e7-91e7-981442e4f155.gif)




