### PR TITLE
Report errors when attempting to sign in

### DIFF
--- a/lib/authentication-provider.js
+++ b/lib/authentication-provider.js
@@ -6,6 +6,7 @@ class AuthenticationProvider {
     this.client = client
     this.client.onSignInChange(() => this.emitter.emit('did-change'))
     this.credentialCache = credentialCache
+    this.notificationManager = notificationManager
     this.emitter = new Emitter()
   }
 
@@ -39,7 +40,7 @@ class AuthenticationProvider {
       const signedIn = await this.client.signIn(token)
       return signedIn
     } catch (error) {
-      this.notificationManager.addError('Failed to sign in', {
+      this.notificationManager.addError('Failed to authenticate to teletype', {
         description: `Signing in failed with error: <code>${error.message}</code>`,
         dismissable: true
       })


### PR DESCRIPTION
Previously, we were failing to report notifications whenever a user attempted to sign in but encountered an error. The problem was due to an oversight when assigning the `NotificationManager` instance in the `AuthenticationProvider` constructor.

This pull-request fixes it and adds a test to prove `AuthenticationProvider` is wired up correctly.

/cc: @nathansobo @jasonrudolph 