### PR TITLE
Fix broken editor rendering after changing font size on guest portals

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -155,6 +155,8 @@ class GuestPortalBinding {
     this.newActivePaneItem = newActivePaneItem
 
     if (this.activePaneItem) {
+      this.ensurePaneItemStylesAreUpToDate(newActivePaneItem)
+
       const pane = this.workspace.paneForItem(this.activePaneItem)
       const index = pane.getItems().indexOf(this.activePaneItem)
       pane.addItem(newActivePaneItem, {index, moved: this.addedPaneItems.has(newActivePaneItem)})
@@ -168,6 +170,18 @@ class GuestPortalBinding {
     if (this.activePaneItemDestroySubscription) this.activePaneItemDestroySubscription.dispose()
     this.activePaneItemDestroySubscription = this.activePaneItem.onDidDestroy(this.leave.bind(this))
     this.newActivePaneItem = null
+  }
+
+  ensurePaneItemStylesAreUpToDate (paneItem) {
+    // When editor styles change, Atom notifies only editor components that
+    // are attached to the DOM at the moment of the change. Thus, if the
+    // element we are about to add had already been rendered, we will
+    // preemptively clear all its styling information to ensure it will render
+    // correctly even if some styles changed while it was not attached to the
+    // DOM.
+    if (this.addedPaneItems.has(paneItem) && paneItem instanceof TextEditor) {
+      paneItem.component.didUpdateStyles()
+    }
   }
 
   getActivePaneItem () {


### PR DESCRIPTION
Fixes #174 

When editor styles change, Atom notifies only editor components that are attached to the DOM at the moment of the change. Thus, if the element we are about to add had already been rendered, we will preemptively clear all its styling information to ensure it will render correctly even if some styles changed while it was not attached to the DOM.

This is admittedly something that we should have better support for in core, but this workaround should be an okay stopgap measure.

/cc: @nathansobo @jasonrudolph 