### PR TITLE
Download teletype-server and teletype-client from NPM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "https://user-with-just-readonly-access-to-realtime-repos:924792417376b236ca11cc234bcc95d306dcd1cb@api.github.com/repos/atom/teletype-client/tarball/v0.25.2",
+    "@atom/teletype-client": "^0.26.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {


### PR DESCRIPTION
This pull-request should be merged the day of launch after addressing the following tasks:

* [x] https://github.com/atom/teletype-client/pull/35
* [x] Make @atom/teletype-client public on npmjs.com.
* [x] Use the new @atom/teletype-client version in package.json.
* [x] Restart CI build to ensure it is green.
* [x] Merge this pull-request.

/cc: @nathansobo @jasonrudolph 