### PR TITLE
Add support for `getChangesSinceCheckpoint` API

### DIFF
--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -83,6 +83,10 @@ class BufferBinding {
     }
   }
 
+  getChangesSinceCheckpoint (checkpoint) {
+    return this.bufferProxy.getChangesSinceCheckpoint(checkpoint)
+  }
+
   createCheckpoint (options) {
     return this.bufferProxy.createCheckpoint(options)
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.26.0",
+    "@atom/teletype-client": "^0.27.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -626,7 +626,7 @@ suite('TeletypePackage', function () {
     assert.equal(hostEditor.getText(), 'abcdefg')
   })
 
-  test('reverting to a checkpoint', async () => {
+  test('checkpoints', async () => {
     const hostEnv = buildAtomEnvironment()
     const hostPackage = await buildPackage(hostEnv)
     const hostEditor = await hostEnv.workspace.open()
@@ -645,6 +645,13 @@ suite('TeletypePackage', function () {
     hostEditor.insertText('j')
     assert.equal(hostEditor.getText(), 'abcdefghij')
     await editorsEqual(hostEditor, guestEditor)
+
+    const changesSinceCheckpoint = hostEditor.getBuffer().getChangesSinceCheckpoint(checkpoint)
+    assert.equal(changesSinceCheckpoint.length, 1)
+    assert.deepEqual(changesSinceCheckpoint[0].oldRange, {start: {row: 0, column: 7}, end: {row: 0, column: 7}})
+    assert.deepEqual(changesSinceCheckpoint[0].oldText, '')
+    assert.deepEqual(changesSinceCheckpoint[0].newRange, {start: {row: 0, column: 7}, end: {row: 0, column: 10}})
+    assert.deepEqual(changesSinceCheckpoint[0].newText, 'hij')
 
     hostEditor.revertToCheckpoint(checkpoint)
     assert.equal(hostEditor.getText(), 'abcdefg')


### PR DESCRIPTION
Fixes #189

This was an oversight when implementing `HistoryProvider` APIs: we added this method to teletype-crdt but forgot to add it to `BufferProxy` (in teletype-client) and `BufferBinding` (in this package).

I have tested that this fixes the above issue with vim-mode-plus.