### PR TITLE
Trim whitespace from portal ID

### DIFF
--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -54,7 +54,8 @@ class JoinPortalComponent {
   async showPrompt () {
     await this.update({promptVisible: true})
 
-    const clipboardText = this.props.clipboard.read().trim()
+    const clipboardText = this.props.clipboard.read()
+    if (clipboardText) clipboardText = clipboardText.trim()
     if (isUUID(clipboardText)) {
       this.refs.portalIdEditor.setText(clipboardText)
     }

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -54,7 +54,7 @@ class JoinPortalComponent {
   async showPrompt () {
     await this.update({promptVisible: true})
 
-    const clipboardText = this.props.clipboard.read()
+    let clipboardText = this.props.clipboard.read()
     if (clipboardText) clipboardText = clipboardText.trim()
     if (isUUID(clipboardText)) {
       this.refs.portalIdEditor.setText(clipboardText)

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -54,7 +54,7 @@ class JoinPortalComponent {
   async showPrompt () {
     await this.update({promptVisible: true})
 
-    const clipboardText = this.props.clipboard.read()
+    const clipboardText = this.props.clipboard.read().trim()
     if (isUUID(clipboardText)) {
       this.refs.portalIdEditor.setText(clipboardText)
     }
@@ -67,7 +67,7 @@ class JoinPortalComponent {
 
   async joinPortal () {
     const {portalBindingManager} = this.props
-    const portalId = this.refs.portalIdEditor.getText()
+    const portalId = this.refs.portalIdEditor.getText().trim()
 
     await this.update({joining: true})
     if (await portalBindingManager.createGuestPortalBinding(portalId)) {

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -136,6 +136,27 @@ suite('PortalListComponent', function () {
     await condition(() => queryParticipantElements(guestPortalBindingsContainer).length === 2)
     assert(queryParticipantElement(guestPortalBindingsContainer, 1))
     assert(queryParticipantElement(guestPortalBindingsContainer, 2))
+    
+    // Insert a valid portal id but with leading and trailing whitespace.
+    const hostPortalBindingManager = await buildPortalBindingManager()
+    const {portal: hostPortal} = await hostPortalBindingManager.createHostPortalBinding()
+
+    joinPortalComponent.refs.portalIdEditor.setText('\t  ' + hostPortal.id + '\n\r\n')
+    joinPortalComponent.joinPortal()
+
+    await condition(() => (
+      !joinPortalComponent.refs.joinPortalLabel &&
+      joinPortalComponent.refs.joiningSpinner &&
+      !joinPortalComponent.refs.portalIdEditor
+    ))
+    await condition(() => (
+      joinPortalComponent.refs.joinPortalLabel &&
+      !joinPortalComponent.refs.joiningSpinner &&
+      !joinPortalComponent.refs.portalIdEditor
+    ))
+    await condition(() => queryParticipantElements(guestPortalBindingsContainer).length === 2)
+    assert(queryParticipantElement(guestPortalBindingsContainer, 1))
+    assert(queryParticipantElement(guestPortalBindingsContainer, 2))
 
     // Simulate another guest joining the portal.
     const newGuestPortalBindingManager = await buildPortalBindingManager()
@@ -153,6 +174,23 @@ suite('PortalListComponent', function () {
     const {joinPortalComponent} = component.refs
 
     clipboard.write('bc282ad8-7643-42cb-80ca-c243771a618f')
+    await joinPortalComponent.showPrompt()
+
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
+
+    await joinPortalComponent.hidePrompt()
+    clipboard.write('not a portal id')
+    await joinPortalComponent.showPrompt()
+
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), '')
+  })
+  
+  test('prefilling portal ID with whitespace from clipboard', async () => {
+    const {component} = await buildComponent()
+    const {clipboard} = component.props
+    const {joinPortalComponent} = component.refs
+
+    clipboard.write('\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
     await joinPortalComponent.showPrompt()
 
     assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -138,6 +138,8 @@ suite('PortalListComponent', function () {
     assert(queryParticipantElement(guestPortalBindingsContainer, 2))
     
     // Insert a valid portal id but with leading and trailing whitespace.
+    await joinPortalComponent.showPrompt()
+
     joinPortalComponent.refs.portalIdEditor.setText('\t  ' + hostPortal.id + '\n\r\n')
     joinPortalComponent.joinPortal()
 
@@ -190,7 +192,7 @@ suite('PortalListComponent', function () {
     clipboard.write('\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
     await joinPortalComponent.showPrompt()
 
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), '\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
 
     await joinPortalComponent.hidePrompt()
     clipboard.write('not a portal id')

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -138,9 +138,6 @@ suite('PortalListComponent', function () {
     assert(queryParticipantElement(guestPortalBindingsContainer, 2))
     
     // Insert a valid portal id but with leading and trailing whitespace.
-    const hostPortalBindingManager = await buildPortalBindingManager()
-    const {portal: hostPortal} = await hostPortalBindingManager.createHostPortalBinding()
-
     joinPortalComponent.refs.portalIdEditor.setText('\t  ' + hostPortal.id + '\n\r\n')
     joinPortalComponent.joinPortal()
 

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -193,7 +193,7 @@ suite('PortalListComponent', function () {
     clipboard.write('\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
     await joinPortalComponent.showPrompt()
 
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), '\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
 
     await joinPortalComponent.hidePrompt()
     clipboard.write('not a portal id')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Trims any whitespace off of a potential portal ID.  The automatic clipboard reading is super cool :).

### Alternate Designs

None.

### Benefits

Better portal ID validation.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #197.