### PR TITLE
Streamline tests related to fetching portal ID from clipboard

### DIFF
--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -172,28 +172,20 @@ suite('PortalListComponent', function () {
     const {clipboard} = component.props
     const {joinPortalComponent} = component.refs
 
+    // Clipboard containing a portal ID
     clipboard.write('bc282ad8-7643-42cb-80ca-c243771a618f')
     await joinPortalComponent.showPrompt()
 
     assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
 
+    // Clipboard containing a portal ID with surrounding whitespace
     await joinPortalComponent.hidePrompt()
-    clipboard.write('not a portal id')
+    clipboard.write('\te40fa1b5-8144-4d09-9dff-c26e7b10b366  \n')
     await joinPortalComponent.showPrompt()
 
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), '')
-  })
-  
-  test('prefilling portal ID with whitespace from clipboard', async () => {
-    const {component} = await buildComponent()
-    const {clipboard} = component.props
-    const {joinPortalComponent} = component.refs
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'e40fa1b5-8144-4d09-9dff-c26e7b10b366')
 
-    clipboard.write('\tbc282ad8-7643-42cb-80ca-c243771a618f  \n')
-    await joinPortalComponent.showPrompt()
-
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
-
+    // Clipboard containing something that is NOT a portal ID
     await joinPortalComponent.hidePrompt()
     clipboard.write('not a portal id')
     await joinPortalComponent.showPrompt()


### PR DESCRIPTION
The changes in https://github.com/atom/teletype/pull/198 duplicated the test for how we handle the scenario where the clipboard contains content that is _not_ a portal ID:

https://github.com/atom/teletype/blob/5a4a7d473265396c14ad9a0ce435b3529040fb13/test/portal-list-component.test.js#L180-L184

Those assertions ☝️ existed prior to #198, and #198 duplicates those existing assertions:

https://github.com/atom/teletype/blob/5a4a7d473265396c14ad9a0ce435b3529040fb13/test/portal-list-component.test.js#L197-L201

This PR removes that duplication. 

---

Also, prior to #198, we had a single `test` function that covered all scenarios related to fetching the portal ID from the clipboard. #198 added a second `test` function specifically related to the scenario where the clipboard contains a portal ID surrounded by whitespace. This PR consolidates that scenario into the pre-existing `test` function, along with the other related scenarios.