### PR TITLE
Fix pusher warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,8 @@ module.exports = new TeletypePackage({
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,
   pusherKey: atom.config.get('teletype.pusherKey'),
+  pusherOptions: {
+    cluster: atom.config.get('teletype.pusherCluster'),
+  },
   baseURL: atom.config.get('teletype.baseURL')
 })

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -9,7 +9,7 @@ class TeletypePackage {
   constructor (options) {
     const {
       workspace, notificationManager, commandRegistry, tooltipManager, clipboard,
-      credentialCache, pubSubGateway, pusherKey, baseURL, tetherDisconnectWindow
+      credentialCache, pubSubGateway, pusherKey, pusherOptions, baseURL, tetherDisconnectWindow
     } = options
 
     this.workspace = workspace
@@ -19,11 +19,13 @@ class TeletypePackage {
     this.clipboard = clipboard
     this.pubSubGateway = pubSubGateway
     this.pusherKey = pusherKey
+    this.pusherOptions = pusherOptions
     this.baseURL = baseURL
     this.tetherDisconnectWindow = tetherDisconnectWindow
     this.credentialCache = credentialCache || new CredentialCache()
     this.client = new TeletypeClient({
       pusherKey: this.pusherKey,
+      pusherOptions: this.pusherOptions,
       baseURL: this.baseURL,
       pubSubGateway: this.pubSubGateway,
       tetherDisconnectWindow: this.tetherDisconnectWindow

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.27.0",
+    "@atom/teletype-client": "^0.28.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,13 @@
       "type": "string",
       "default": "f119821248b7429bece3",
       "order": 2
+    },
+    "pusherCluster": {
+      "title": "Pusher cluster name",
+      "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
+      "type": "string",
+      "default": "mt1",
+      "order": 3
     }
   }
 }


### PR DESCRIPTION
Closes #204
Fixes #202

This incorporates the changes from @icetee in #204 and updates teletype-client to support the new `pusherOptions` parameter (see https://github.com/atom/teletype-client/pull/37).