### PR TITLE
Show initialization failures also in the popover

### DIFF
--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -1,0 +1,31 @@
+const etch = require('etch')
+const $ = etch.dom
+
+module.exports =
+class PackageInitializationErrorComponent {
+  constructor (props) {
+    this.props = props
+    etch.initialize(this)
+  }
+
+  update (props) {
+    Object.assign(this.props, props)
+    return etch.update(this)
+  }
+
+  render () {
+    return $.div({className: 'PackageInitializationErrorComponent'},
+      $.h3(null, 'Teletype initialization failed'),
+      $.p(null, 'Make sure your internet connection is working and restart the package.'),
+      $.p(null,
+        'If the problem persists, visit ',
+        $.a({href: 'https://github.com/atom/teletype/issues/new', className: 'text-info'}, 'atom/teletype'),
+        ' and open an issue.'
+      )
+    )
+  }
+
+  viewPackageSettings () {
+    return this.props.workspace.open('atom://config/packages/teletype')
+  }
+}

--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -24,8 +24,4 @@ class PackageInitializationErrorComponent {
       )
     )
   }
-
-  viewPackageSettings () {
-    return this.props.workspace.open('atom://config/packages/teletype')
-  }
 }

--- a/lib/popover-component.js
+++ b/lib/popover-component.js
@@ -3,6 +3,7 @@ const $ = etch.dom
 const PortalListComponent = require('./portal-list-component')
 const SignInComponent = require('./sign-in-component')
 const PackageOutdatedComponent = require('./package-outdated-component')
+const PackageInitializationErrorComponent = require('./package-initialization-error-component')
 
 module.exports =
 class PopoverComponent {
@@ -20,7 +21,8 @@ class PopoverComponent {
 
   render () {
     const {
-      isClientOutdated, authenticationProvider, portalBindingManager,
+      isClientOutdated, initializationError,
+      authenticationProvider, portalBindingManager,
       commandRegistry, credentialCache, clipboard, workspace
     } = this.props
 
@@ -29,6 +31,10 @@ class PopoverComponent {
       activeComponent = $(PackageOutdatedComponent, {
         ref: 'packageOutdatedComponent',
         workspace
+      })
+    } else if (initializationError) {
+      activeComponent = $(PackageInitializationErrorComponent, {
+        ref: 'packageInitializationErrorComponent'
       })
     } else if (this.props.authenticationProvider.isSignedIn()) {
       activeComponent = $(PortalListComponent, {

--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -53,6 +53,7 @@ function buildElement (props) {
   const anchor = document.createElement('a')
   anchor.classList.add('PortalStatusBarIndicator', 'inline-block')
   if (props.isClientOutdated) anchor.classList.add('outdated')
+  if (props.initializationError) anchor.classList.add('initialization-error')
 
   const icon = document.createElement('span')
   icon.classList.add('icon', 'icon-radio-tower')

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -106,6 +106,7 @@ class TeletypePackage {
       portalBindingManager,
       authenticationProvider,
       isClientOutdated: this.isClientOutdated,
+      initializationError: this.initializationError,
       tooltipManager: this.tooltipManager,
       commandRegistry: this.commandRegistry,
       clipboard: this.clipboard,
@@ -208,6 +209,7 @@ class TeletypePackage {
       if (error instanceof Errors.ClientOutOfDateError) {
         this.isClientOutdated = true
       } else {
+        this.initializationError = error
         this.notificationManager.addError('Failed to initialize the teletype package', {
           description: `Establishing a teletype connection failed with error: <code>${error.message}</code>`,
           dismissable: true

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -202,6 +202,9 @@ class TeletypePackage {
   }
 
   async getClient () {
+    if (this.initializationError) return null
+    if (this.isClientOutdated) return null
+
     try {
       await this.client.initialize()
       return this.client

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -411,13 +411,7 @@
   }
 }
 
-.PackageOutdatedComponent {
-  color: @text-color;
-  text-align: center;
-  padding: 0 @component-padding @component-padding @component-padding;
-}
-
-.PackageInitializationErrorComponent {
+.PackageOutdatedComponent, .PackageInitializationErrorComponent {
   color: @text-color;
   text-align: center;
   padding: 0 @component-padding @component-padding @component-padding;

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -416,3 +416,9 @@
   text-align: center;
   padding: 0 @component-padding @component-padding @component-padding;
 }
+
+.PackageInitializationErrorComponent {
+  color: @text-color;
+  text-align: center;
+  padding: 0 @component-padding @component-padding @component-padding;
+}

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -18,7 +18,7 @@
     }
   }
 
-  &.outdated {
+  &.outdated, &.initialization-error {
     color: @text-color-error;
 
     &:hover {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -940,6 +940,7 @@ suite('TeletypePackage', function () {
       assert(description.includes('an error'))
 
       const {popoverComponent} = pack.portalStatusBarIndicator
+      assert(pack.portalStatusBarIndicator.element.classList.contains('initialization-error'))
       assert(popoverComponent.refs.packageInitializationErrorComponent)
     }
   })

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -889,15 +889,12 @@ suite('TeletypePackage', function () {
   })
 
   test('reports errors attempting to initialize the client', async () => {
-    const env = buildAtomEnvironment()
-    const pack = await buildPackage(env, {signIn: false})
-    pack.client.initialize = async function () {
-      await Promise.resolve()
-      throw new Error('an error')
-    }
-
     {
-      env.notifications.clear()
+      const env = buildAtomEnvironment()
+      const pack = await buildPackage(env, {signIn: false})
+      pack.client.initialize = async function () {
+        throw new Error('an error')
+      }
 
       await pack.sharePortal()
 
@@ -910,7 +907,11 @@ suite('TeletypePackage', function () {
     }
 
     {
-      env.notifications.clear()
+      const env = buildAtomEnvironment()
+      const pack = await buildPackage(env, {signIn: false})
+      pack.client.initialize = async function () {
+        throw new Error('an error')
+      }
 
       await pack.joinPortal()
 
@@ -920,6 +921,26 @@ suite('TeletypePackage', function () {
       assert.equal(type, 'error')
       assert.equal(message, 'Failed to initialize the teletype package')
       assert(description.includes('an error'))
+    }
+
+    {
+      const env = buildAtomEnvironment()
+      const pack = await buildPackage(env, {signIn: false})
+      pack.client.initialize = async function () {
+        throw new Error('an error')
+      }
+
+      await pack.consumeStatusBar(new FakeStatusBar())
+
+      assert.equal(env.notifications.getNotifications().length, 1)
+      const {type, message, options} = env.notifications.getNotifications()[0]
+      const {description} = options
+      assert.equal(type, 'error')
+      assert.equal(message, 'Failed to initialize the teletype package')
+      assert(description.includes('an error'))
+
+      const {popoverComponent} = pack.portalStatusBarIndicator
+      assert(popoverComponent.refs.packageInitializationErrorComponent)
     }
   })
 


### PR DESCRIPTION
Fixes #210 

Previously, we would only show a notification when failing to initialize the client (e.g. this could happen when an error occurs while checking the protocol version) without informing the popover. This was also causing exceptions like #210, because we were failing to instantiate objects like `PortalBindingManager` due to the initialization error.

With this pull-request we will:

* Show an error message in the popover too, coloring the status bar indicator as red when that happens.
* Don't attempt to re-initialize the client if it is outdated or an error has previously occurred.

<p align=center>
<img src="https://user-images.githubusercontent.com/482957/32887103-06dfc82a-cac3-11e7-8b25-9b220594cf7b.png">
</p>

I have tested this works correctly with a few themes (One Light UI, One Dark UI, Atom Material, Nord UI) by opening the DevTools and enabling the `Offline` checkbox in the Network tab. On reload, I verified that the above message was being shown in the popover.

/cc: @jasonrudolph @nathansobo 