### PR TITLE
Dispose of status bar and commands when deactivating

### DIFF
--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -34,7 +34,7 @@ class PortalStatusBarIndicator {
     )
   }
 
-  detach () {
+  destroy () {
     if (this.tile) this.tile.destroy()
     if (this.tooltip) this.tooltip.dispose()
     this.subscriptions.dispose()

--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -23,7 +23,7 @@ class PortalStatusBarIndicator {
       item: this,
       priority: PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR
     })
-    this.tooltip = props.tooltipManager.add(
+    this.tooltip = this.props.tooltipManager.add(
       this.element,
       {
         item: this.popoverComponent,

--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -8,6 +8,21 @@ class PortalStatusBarIndicator {
     this.subscriptions = new CompositeDisposable()
     this.element = buildElement(props)
     this.popoverComponent = new PopoverComponent(props)
+
+    if (props.portalBindingManager) {
+      this.portalBindingManager = props.portalBindingManager
+      this.subscriptions.add(this.portalBindingManager.onDidChange(() => {
+        this.updatePortalStatus()
+      }))
+    }
+  }
+
+  attach () {
+    const PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR = -40
+    this.tile = this.props.statusBar.addRightTile({
+      item: this,
+      priority: PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR
+    })
     this.tooltip = props.tooltipManager.add(
       this.element,
       {
@@ -17,13 +32,12 @@ class PortalStatusBarIndicator {
         placement: 'top'
       }
     )
+  }
 
-    if (props.portalBindingManager) {
-      this.portalBindingManager = props.portalBindingManager
-      this.subscriptions.add(this.portalBindingManager.onDidChange(() => {
-        this.updatePortalStatus()
-      }))
-    }
+  detach () {
+    if (this.tile) this.tile.destroy()
+    if (this.tooltip) this.tooltip.dispose()
+    this.subscriptions.dispose()
   }
 
   showPopover () {
@@ -41,11 +55,6 @@ class PortalStatusBarIndicator {
     } else {
       this.element.classList.remove('transmitting')
     }
-  }
-
-  dispose () {
-    this.tooltip.dispose()
-    this.subscriptions.dispose()
   }
 }
 

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -57,7 +57,7 @@ class TeletypePackage {
   }
 
   async deactivate () {
-    this.subscriptions.dispose()
+    if (this.subscriptions) this.subscriptions.dispose() // Package is not activated in specs
     if (this.portalStatusBarIndicator) this.portalStatusBarIndicator.detach()
 
     if (this.portalBindingManagerPromise) {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -58,7 +58,7 @@ class TeletypePackage {
 
   async deactivate () {
     if (this.subscriptions) this.subscriptions.dispose() // Package is not activated in specs
-    if (this.portalStatusBarIndicator) this.portalStatusBarIndicator.detach()
+    if (this.portalStatusBarIndicator) this.portalStatusBarIndicator.destroy()
 
     if (this.portalBindingManagerPromise) {
       const manager = await this.portalBindingManagerPromise

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -1,4 +1,5 @@
 const {TeletypeClient, Errors} = require('@atom/teletype-client')
+const {CompositeDisposable} = require('atom')
 const PortalBindingManager = require('./portal-binding-manager')
 const PortalStatusBarIndicator = require('./portal-status-bar-indicator')
 const AuthenticationProvider = require('./authentication-provider')
@@ -34,35 +35,35 @@ class TeletypePackage {
     this.portalBindingManagerPromise = null
   }
 
-  async dispose () {
-    if (this.portalStatusBarIndicator) {
-      this.statusBarTile.destroy()
-      this.portalStatusBarIndicator.dispose()
-    }
+  activate () {
+    console.log('teletype: Using pusher key:', this.pusherKey)
+    console.log('teletype: Using base URL:', this.baseURL)
+
+    this.subscriptions = new CompositeDisposable()
+
+    this.subscriptions.add(this.commandRegistry.add('atom-workspace', {
+      'teletype:share-portal': () => this.sharePortal()
+    }))
+    this.subscriptions.add(this.commandRegistry.add('atom-workspace', {
+      'teletype:join-portal': () => this.joinPortal()
+    }))
+    this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
+      'teletype:close-portal': () => this.closeHostPortal()
+    }))
+
+    // Initiate sign-in, which will continue asynchronously, since we don't want
+    // to block here.
+    this.signInUsingSavedToken()
+  }
+
+  async deactivate () {
+    this.subscriptions.dispose()
+    if (this.portalStatusBarIndicator) this.portalStatusBarIndicator.detach()
 
     if (this.portalBindingManagerPromise) {
       const manager = await this.portalBindingManagerPromise
       await manager.dispose()
     }
-  }
-
-  activate () {
-    console.log('teletype: Using pusher key:', this.pusherKey)
-    console.log('teletype: Using base URL:', this.baseURL)
-
-    this.commandRegistry.add('atom-workspace', {
-      'teletype:share-portal': () => this.sharePortal()
-    })
-    this.commandRegistry.add('atom-workspace', {
-      'teletype:join-portal': () => this.joinPortal()
-    })
-    this.commandRegistry.add('atom-workspace.teletype-Host', {
-      'teletype:close-portal': () => this.closeHostPortal()
-    })
-
-    // Initiate sign-in, which will continue asynchronously, since we don't want
-    // to block here.
-    this.signInUsingSavedToken()
   }
 
   async sharePortal () {
@@ -102,6 +103,7 @@ class TeletypePackage {
     const portalBindingManager = await this.getPortalBindingManager()
     const authenticationProvider = await this.getAuthenticationProvider()
     this.portalStatusBarIndicator = new PortalStatusBarIndicator({
+      statusBar,
       teletypeClient,
       portalBindingManager,
       authenticationProvider,
@@ -112,11 +114,7 @@ class TeletypePackage {
       workspace: this.workspace
     })
 
-    const PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR = -40
-    this.statusBarTile = statusBar.addRightTile({
-      item: this.portalStatusBarIndicator,
-      priority: PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR
-    })
+    this.portalStatusBarIndicator.attach()
   }
 
   async signInUsingSavedToken () {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -48,7 +48,7 @@ suite('TeletypePackage', function () {
     containerElement.remove()
 
     for (const pack of packages) {
-      await pack.dispose()
+      await pack.deactivate()
     }
     await destroyAtomEnvironments()
   })

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -975,7 +975,7 @@ suite('TeletypePackage', function () {
 
     if (options.signIn == null || options.signIn) {
       await credentialCache.set('oauth-token', 'token-' + nextTokenId++)
-      await pack.activate()
+      await pack.signInUsingSavedToken()
     }
     packages.push(pack)
     return pack

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -975,7 +975,7 @@ suite('TeletypePackage', function () {
 
     if (options.signIn == null || options.signIn) {
       await credentialCache.set('oauth-token', 'token-' + nextTokenId++)
-      await pack.signInUsingSavedToken()
+      await pack.activate()
     }
     packages.push(pack)
     return pack


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

On package deactivation, remove any added commands and the status bar tile, if present.  There was an existing `dispose` method, but that never gets called.  The proper name is `deactivate`.

Test plan:
* Disable teletype
* Try searching for `teletype` commands (expected: none to exist)
* Status bar tile should not be visible
* Re-enable teletype
* Try searching for `teletype` commands (expected: commands exist)
* Status bar tile should be visible

### Alternate Designs

None.

### Benefits

Proper package deactivation.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #199