### PR TITLE
Heavily defer requires for faster activation time

### DIFF
--- a/lib/popover-component.js
+++ b/lib/popover-component.js
@@ -1,9 +1,9 @@
 const etch = require('etch')
 const $ = etch.dom
-const PortalListComponent = require('./portal-list-component')
-const SignInComponent = require('./sign-in-component')
-const PackageOutdatedComponent = require('./package-outdated-component')
-const PackageInitializationErrorComponent = require('./package-initialization-error-component')
+let PortalListComponent = null
+let SignInComponent = null
+let PackageOutdatedComponent = null
+let PackageInitializationErrorComponent = null
 
 module.exports =
 class PopoverComponent {
@@ -28,15 +28,18 @@ class PopoverComponent {
 
     let activeComponent
     if (isClientOutdated) {
+      if (!PackageOutdatedComponent) PackageOutdatedComponent = require('./package-outdated-component')
       activeComponent = $(PackageOutdatedComponent, {
         ref: 'packageOutdatedComponent',
         workspace
       })
     } else if (initializationError) {
+      if (!PackageInitializationErrorComponent) PackageInitializationErrorComponent = require('./package-initialization-error-component')
       activeComponent = $(PackageInitializationErrorComponent, {
         ref: 'packageInitializationErrorComponent'
       })
     } else if (this.props.authenticationProvider.isSignedIn()) {
+      if (!PortalListComponent) PortalListComponent = require('./portal-list-component')
       activeComponent = $(PortalListComponent, {
         ref: 'portalListComponent',
         localUserIdentity: authenticationProvider.getIdentity(),
@@ -45,6 +48,7 @@ class PopoverComponent {
         commandRegistry
       })
     } else {
+      if (!SignInComponent) SignInComponent = require('./sign-in-component')
       activeComponent = $(SignInComponent, {
         ref: 'signInComponent',
         authenticationProvider,

--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -1,5 +1,5 @@
 const {CompositeDisposable} = require('atom')
-const PopoverComponent = require('./popover-component')
+let PopoverComponent = null
 
 module.exports =
 class PortalStatusBarIndicator {
@@ -7,14 +7,7 @@ class PortalStatusBarIndicator {
     this.props = props
     this.subscriptions = new CompositeDisposable()
     this.element = buildElement(props)
-    this.popoverComponent = new PopoverComponent(props)
-
-    if (props.portalBindingManager) {
-      this.portalBindingManager = props.portalBindingManager
-      this.subscriptions.add(this.portalBindingManager.onDidChange(() => {
-        this.updatePortalStatus()
-      }))
-    }
+    this.element.onclick = this.handleInitialClick.bind(this)
   }
 
   attach () {
@@ -23,15 +16,6 @@ class PortalStatusBarIndicator {
       item: this,
       priority: PRIORITY_BETWEEN_BRANCH_NAME_AND_GRAMMAR
     })
-    this.tooltip = this.props.tooltipManager.add(
-      this.element,
-      {
-        item: this.popoverComponent,
-        class: 'TeletypePopoverTooltip',
-        trigger: 'click',
-        placement: 'top'
-      }
-    )
   }
 
   destroy () {
@@ -55,6 +39,34 @@ class PortalStatusBarIndicator {
     } else {
       this.element.classList.remove('transmitting')
     }
+  }
+
+  async handleInitialClick () {
+    this.element.onclick = null
+    this.portalBindingManager = await this.props.getPortalBindingManager()
+    this.subscriptions.add(this.portalBindingManager.onDidChange(() => {
+      this.updatePortalStatus()
+    }))
+
+    this.authenticationProvider = await this.props.getAuthenticationProvider()
+    await this.authenticationProvider.signInUsingSavedToken()
+
+    if (!PopoverComponent) PopoverComponent = require('./popover-component')
+    this.popoverComponent = new PopoverComponent(Object.assign(
+      {portalBindingManager: this.portalBindingManager},
+      {authenticationProvider: this.authenticationProvider},
+      this.props
+    ))
+    this.tooltip = this.props.tooltipManager.add(
+      this.element,
+      {
+        item: this.popoverComponent,
+        class: 'TeletypePopoverTooltip',
+        trigger: 'click',
+        placement: 'top'
+      }
+    )
+    this.element.click()
   }
 }
 

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -1,9 +1,9 @@
-const {TeletypeClient, Errors} = require('@atom/teletype-client')
 const {CompositeDisposable} = require('atom')
-const PortalBindingManager = require('./portal-binding-manager')
-const PortalStatusBarIndicator = require('./portal-status-bar-indicator')
-const AuthenticationProvider = require('./authentication-provider')
-const CredentialCache = require('./credential-cache')
+let [TeletypeClient, Errors] = []
+let PortalBindingManager = null
+let PortalStatusBarIndicator = null
+let AuthenticationProvider = null
+let CredentialCache = null
 
 module.exports =
 class TeletypePackage {
@@ -23,21 +23,13 @@ class TeletypePackage {
     this.pusherOptions = pusherOptions
     this.baseURL = baseURL
     this.tetherDisconnectWindow = tetherDisconnectWindow
-    this.credentialCache = credentialCache || new CredentialCache()
-    this.client = new TeletypeClient({
-      pusherKey: this.pusherKey,
-      pusherOptions: this.pusherOptions,
-      baseURL: this.baseURL,
-      pubSubGateway: this.pubSubGateway,
-      tetherDisconnectWindow: this.tetherDisconnectWindow
-    })
-    this.client.onConnectionError(this.handleConnectionError.bind(this))
+    this.credentialCache = credentialCache
     this.portalBindingManagerPromise = null
   }
 
   activate () {
-    console.log('teletype: Using pusher key:', this.pusherKey)
-    console.log('teletype: Using base URL:', this.baseURL)
+    // console.log('teletype: Using pusher key:', this.pusherKey)
+    // console.log('teletype: Using base URL:', this.baseURL)
 
     this.subscriptions = new CompositeDisposable()
 
@@ -50,10 +42,6 @@ class TeletypePackage {
     this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
       'teletype:close-portal': () => this.closeHostPortal()
     }))
-
-    // Initiate sign-in, which will continue asynchronously, since we don't want
-    // to block here.
-    this.signInUsingSavedToken()
   }
 
   async deactivate () {
@@ -62,11 +50,12 @@ class TeletypePackage {
 
     if (this.portalBindingManagerPromise) {
       const manager = await this.portalBindingManagerPromise
-      await manager.dispose()
+      if (manager) await manager.dispose()
     }
   }
 
   async sharePortal () {
+    await this.signInUsingSavedToken()
     this.showPopover()
 
     if (await this.isSignedIn()) {
@@ -77,6 +66,7 @@ class TeletypePackage {
   }
 
   async joinPortal (id) {
+    await this.signInUsingSavedToken()
     this.showPopover()
 
     if (await this.isSignedIn()) {
@@ -99,16 +89,14 @@ class TeletypePackage {
   }
 
   async consumeStatusBar (statusBar) {
-    const teletypeClient = await this.getClient()
-    const portalBindingManager = await this.getPortalBindingManager()
-    const authenticationProvider = await this.getAuthenticationProvider()
+    const getPortalBindingManager = async () => await this.getPortalBindingManager()
+    const getAuthenticationProvider = async () => await this.getAuthenticationProvider()
+    if (!PortalStatusBarIndicator) PortalStatusBarIndicator = require('./portal-status-bar-indicator')
     this.portalStatusBarIndicator = new PortalStatusBarIndicator({
       statusBar,
-      teletypeClient,
-      portalBindingManager,
-      authenticationProvider,
+      getPortalBindingManager,
+      getAuthenticationProvider,
       isClientOutdated: this.isClientOutdated,
-      initializationError: this.initializationError,
       tooltipManager: this.tooltipManager,
       commandRegistry: this.commandRegistry,
       clipboard: this.clipboard,
@@ -160,15 +148,23 @@ class TeletypePackage {
   }
 
   getAuthenticationProvider () {
+    if (this.authenticationProvider) return Promise.resolve(this.authenticationProvider)
+
     if (!this.authenticationProviderPromise) {
       this.authenticationProviderPromise = new Promise(async (resolve, reject) => {
         const client = await this.getClient()
         if (client) {
-          resolve(new AuthenticationProvider({
+          if (!AuthenticationProvider) AuthenticationProvider = require('./authentication-provider')
+          if (!this.credentialCache) {
+            if (!CredentialCache) CredentialCache = require('./credential-cache')
+            this.credentialCache = new CredentialCache()
+          }
+          this.authenticationProvider = new AuthenticationProvider({
             client,
             credentialCache: this.credentialCache,
             notificationManager: this.notificationManager
-          }))
+          })
+          resolve(this.authenticationProvider)
         } else {
           this.authenticationProviderPromise = null
           resolve(null)
@@ -180,15 +176,19 @@ class TeletypePackage {
   }
 
   getPortalBindingManager () {
+    if (this.portalBindingManager) return Promise.resolve(this.portalBindingManager)
+
     if (!this.portalBindingManagerPromise) {
       this.portalBindingManagerPromise = new Promise(async (resolve, reject) => {
         const client = await this.getClient()
         if (client) {
-          resolve(new PortalBindingManager({
+          if (!PortalBindingManager) PortalBindingManager = require('./portal-binding-manager')
+          this.portalBindingManager = new PortalBindingManager({
             client,
             workspace: this.workspace,
             notificationManager: this.notificationManager
-          }))
+          })
+          resolve(this.portalBindingManager)
         } else {
           this.portalBindingManagerPromise = null
           resolve(null)
@@ -200,17 +200,28 @@ class TeletypePackage {
   }
 
   async getClient () {
-    if (this.initializationError) return null
-    if (this.isClientOutdated) return null
-
     try {
+      if(!TeletypeClient) ({TeletypeClient, Errors} = require('@atom/teletype-client'))
+      if (this.client) {
+        await this.client.initialize()
+        return this.client
+      }
+
+      this.client = new TeletypeClient({
+        pusherKey: this.pusherKey,
+        pusherOptions: this.pusherOptions,
+        baseURL: this.baseURL,
+        pubSubGateway: this.pubSubGateway,
+        tetherDisconnectWindow: this.tetherDisconnectWindow
+      })
+      this.client.onConnectionError(this.handleConnectionError.bind(this))
+
       await this.client.initialize()
       return this.client
     } catch (error) {
       if (error instanceof Errors.ClientOutOfDateError) {
         this.isClientOutdated = true
       } else {
-        this.initializationError = error
         this.notificationManager.addError('Failed to initialize the teletype package', {
           description: `Establishing a teletype connection failed with error: <code>${error.message}</code>`,
           dismissable: true


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

This PR _heavily_ defers as much work as possible until needed in order to improve activation time (see the drawbacks section for why this isn't all sunshine and rainbows).  Without this PR, it takes around 190ms to activate; with this PR, it takes around 8ms.  Changes include:
* Deferring requires in `teletype-package.js` until a command is activated
  * In order to prevent the status bar tile from activating them immediately anyway, direct references to `AuthenticationProvider` and `PortalBindingManager` have been replaced with lazy getter functions.
  * Caching `AuthenticationProvider`, `PortalBindingManager`, and `TeletypeClient` once they're constructed.  Is this a good idea?  I'm not sure if there's a reason a new object is being constructed each time.
* Deferring creating the popover component in `PortalStatusBarIndicator` until the status bar tile is clicked
  * Again, this is so that `PopoverComponent` doesn't require the same modules that we're trying to defer.  When the tile is first clicked the deferred activation occurs which calls the lazy getter functions, attempts to sign in, creates the popover tooltip, and then displays it.
* Conditionally requiring only the components necessary to render the popover.  Most of the time the `PortalListComponent` will be the only one displayed, so this changes saves us from having to require the other three components as well.
* Commenting out two `console.log`s in the activate method.  I don't know why, but they were delaying startup by ~40ms when I was profiling startup.  It doesn't look like there's a negative performance impact when running Atom regularly though.

### Alternate Designs

Of course, the easier way would be to :fire: the status bar tile entirely and rely only on the commands.  But I don't see another way of doing this while keeping the status bar tile.

### Benefits

Shaves a significant amount of time off of initial package activation, leading to faster Atom startup.

### Possible Drawbacks

_**There is a noticeable delay**_ when first clicking on the tile to bring up the popover.  The delay is potentially long enough that someone might think that Teletype isn't working.  A potential way to improve this is to show a loading spinner on initial click, but that's not something that I looked into implementing for this PR.

### Applicable Issues

Closes #201