### PR TITLE
Disable join button if portal ID is invalid.

### DIFF
--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -54,7 +54,7 @@ class JoinPortalComponent {
   async validatePortalId() {
     //here we validate the portal id is correct. 
     const portalId = this.refs.portalIdEditor.getText().trim()
-    await this.update({ isValidPortalId: portalId && isUUID(portalId) })
+    await this.update({ isValidPortalId: isUUID(portalId) })
   }
 
   async showPrompt () {

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -11,7 +11,7 @@ class JoinPortalComponent {
       'core:confirm': this.joinPortal.bind(this),
       'core:cancel': this.hidePrompt.bind(this)
     })
-  }
+}
 
   destroy () {
     this.disposables.dispose()
@@ -34,7 +34,7 @@ class JoinPortalComponent {
   }
 
   render () {
-    const {joining, promptVisible} = this.props
+    const {joining, promptVisible, isValidPortalId} = this.props
     if (joining) {
       return $.div({className: 'JoinPortalComponent--no-prompt'},
         $.span({ref: 'joiningSpinner', className: 'loading loading-spinner-tiny inline-block'})
@@ -42,7 +42,7 @@ class JoinPortalComponent {
     } else if (promptVisible) {
       return $.div({className: 'JoinPortalComponent--prompt', tabIndex: -1},
         $(TextEditor, {ref: 'portalIdEditor', mini: true, placeholderText: 'Enter a host portal ID...'}),
-        $.button({type: 'button', className: 'btn btn-xs', onClick: this.joinPortal}, 'Join')
+        $.button({ref: 'joinButton', type: 'button', disabled: !isValidPortalId, className: 'btn btn-xs', onClick: this.joinPortal}, 'Join')
       )
     } else {
       return $.div({className: 'JoinPortalComponent--no-prompt'},
@@ -51,8 +51,16 @@ class JoinPortalComponent {
     }
   }
 
+  async validatePortalId() {
+    //here we validate the portal id is correct. 
+    const portalId = this.refs.portalIdEditor.getText().trim()
+    await this.update({ isValidPortalId: portalId && isUUID(portalId) })
+  }
+
   async showPrompt () {
     await this.update({promptVisible: true})
+    //setup the handler for when the portal id value changes
+    this.disposables.add(this.refs.portalIdEditor.onDidChange(this.validatePortalId.bind(this)))
 
     let clipboardText = this.props.clipboard.read()
     if (clipboardText) clipboardText = clipboardText.trim()
@@ -69,12 +77,33 @@ class JoinPortalComponent {
   async joinPortal () {
     const {portalBindingManager} = this.props
     const portalId = this.refs.portalIdEditor.getText().trim()
+    
+    //validate that the portal id has been specified. 
+    if(!portalId){
+        portalBindingManager.notificationManager.addError('Missing portal ID', {
+            description: `A portal id must be specified.`,
+            dismissable: true
+        })
+        return
+    }
+
+    //validate that the portal id is a valid UUID as well
+    if(!isUUID(portalId)){
+        portalBindingManager.notificationManager.addError('Invalid portal ID', {
+            description: `The specified portal ID is invalid.`,
+            dismissable: true
+        })
+        return
+    }
 
     await this.update({joining: true})
     if (await portalBindingManager.createGuestPortalBinding(portalId)) {
-      await this.update({joining: false, promptVisible: false})
+      await this.update({joining: false, promptVisible: false, isValidPortalId: false})
     } else {
-      await this.update({joining: false})
+      await this.update({joining: false, isValidPortalId: false})
+      //after a login attempt, the event is cleared. So set the handler again
+      //when the join failed.
+      this.disposables.add(this.refs.portalIdEditor.onDidChange(this.validatePortalId.bind(this)))
     }
   }
 }

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -94,32 +94,36 @@ suite('PortalListComponent', function () {
     assert(joinPortalComponent.refs.joinPortalLabel)
     assert(!joinPortalComponent.refs.portalIdEditor)
     assert(!joinPortalComponent.refs.joiningSpinner)
-
+    assert(!joinPortalComponent.refs.joinButton)
+    
     await joinPortalComponent.showPrompt()
 
     assert(!joinPortalComponent.refs.joinPortalLabel)
+    assert(joinPortalComponent.refs.joinButton.disabled)
     assert(joinPortalComponent.refs.portalIdEditor)
     assert(!joinPortalComponent.refs.joiningSpinner)
+
+    // Use no portal id
+    joinPortalComponent.joinPortal()
+
+    assert(!joinPortalComponent.refs.joinPortalLabel)
+    assert(!joinPortalComponent.refs.joiningSpinner)
+    assert(joinPortalComponent.refs.portalIdEditor)
+    assert(joinPortalComponent.refs.joinButton.disabled)
 
     // Insert an invalid portal id.
     joinPortalComponent.refs.portalIdEditor.setText('invalid-portal-id')
     joinPortalComponent.joinPortal()
 
-    await condition(() => (
-      !joinPortalComponent.refs.joinPortalLabel &&
-      joinPortalComponent.refs.joiningSpinner &&
-      !joinPortalComponent.refs.portalIdEditor
-    ))
-    await condition(() => (
-      !joinPortalComponent.refs.joinPortalLabel &&
-      !joinPortalComponent.refs.joiningSpinner &&
-      joinPortalComponent.refs.portalIdEditor
-    ))
+    assert(!joinPortalComponent.refs.joinPortalLabel)
+    assert(!joinPortalComponent.refs.joiningSpinner)
+    assert(joinPortalComponent.refs.portalIdEditor)
+    assert(joinPortalComponent.refs.joinButton.disabled)
 
     // Insert a valid portal id.
     const hostPortalBindingManager = await buildPortalBindingManager()
     const {portal: hostPortal} = await hostPortalBindingManager.createHostPortalBinding()
-
+    
     joinPortalComponent.refs.portalIdEditor.setText(hostPortal.id)
     joinPortalComponent.joinPortal()
 
@@ -255,5 +259,5 @@ class FakeNotificationManager {
 }
 
 class FakeCommandRegistry {
-  add () {}
+  add () { return new Set() }
 }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

When attempting to join a new session, the join button did no validation on the specified portal id. This change now disables the join button in the following scenarios:
1. When the portal id is blank
2. When the portal id is not a valid UUID

Once the value has been validated, the button becomes enabled and allows the user to click it.

### Alternate Designs

Originally I considered just showing an error message when the button was clicked, but this felt sloppy since this is more of a input validation step. Using this method, the button prevents the attempt all together unless it is valid. I did include some guards in the join step to prompt the user in the event that an invalid portal id was somehow specified/allowed. I wasn't fully sure if this was something that we would want, so I left in just in case and for some extra protection. I can remove it if requested.

### Benefits

Users will not get a cryptic message when attempting to connect with an invalid id value. It also feels more like a traditional form input since the button blocks all invalid inputs now.

### Possible Drawbacks

Since the button automatically disables/enables, it is possible that somebody may not understand why the button is disabled in the event of an invalid UUID.

### Applicable Issues

- #47