### PR TITLE
Allow users to sign out via `Teletype: Sign out` command

### DIFF
--- a/lib/authentication-provider.js
+++ b/lib/authentication-provider.js
@@ -2,11 +2,12 @@ const {Emitter} = require('atom')
 
 module.exports =
 class AuthenticationProvider {
-  constructor ({client, notificationManager, credentialCache}) {
+  constructor ({client, notificationManager, workspace, credentialCache}) {
     this.client = client
-    this.client.onSignInChange(() => this.emitter.emit('did-change'))
+    this.client.onSignInChange(this.didChangeSignIn.bind(this))
     this.credentialCache = credentialCache
     this.notificationManager = notificationManager
+    this.workspace = workspace
     this.emitter = new Emitter()
   }
 
@@ -32,10 +33,17 @@ class AuthenticationProvider {
     }
   }
 
+  async signOut () {
+    if (!this.isSignedIn()) return
+
+    await this.credentialCache.delete('oauth-token')
+    this.client.signOut()
+  }
+
   async _signIn (token) {
     try {
       this.signingIn = true
-      this.emitter.emit('did-change')
+      this.didChangeSignIn()
 
       const signedIn = await this.client.signIn(token)
       return signedIn
@@ -46,7 +54,7 @@ class AuthenticationProvider {
       })
     } finally {
       this.signingIn = false
-      this.emitter.emit('did-change')
+      this.didChangeSignIn()
     }
   }
 
@@ -64,5 +72,16 @@ class AuthenticationProvider {
 
   onDidChange (callback) {
     return this.emitter.on('did-change', callback)
+  }
+
+  didChangeSignIn () {
+    const workspaceElement = this.workspace.getElement()
+    if (this.isSignedIn()) {
+      workspaceElement.classList.add('teletype-Authenticated')
+    } else {
+      workspaceElement.classList.remove('teletype-Authenticated')
+    }
+
+    this.emitter.emit('did-change')
   }
 }

--- a/lib/portal-status-bar-indicator.js
+++ b/lib/portal-status-bar-indicator.js
@@ -44,6 +44,10 @@ class PortalStatusBarIndicator {
     if (!this.isPopoverVisible()) this.element.click()
   }
 
+  hidePopover () {
+    if (this.isPopoverVisible()) this.element.click()
+  }
+
   isPopoverVisible () {
     return document.contains(this.popoverComponent.element)
   }

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -41,6 +41,9 @@ class TeletypePackage {
 
     this.subscriptions = new CompositeDisposable()
 
+    this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Authenticated', {
+      'teletype:sign-out': () => this.signOut()
+    }))
     this.subscriptions.add(this.commandRegistry.add('atom-workspace', {
       'teletype:share-portal': () => this.sharePortal()
     }))
@@ -127,6 +130,14 @@ class TeletypePackage {
     }
   }
 
+  async signOut () {
+    const authenticationProvider = await this.getAuthenticationProvider()
+    if (authenticationProvider) {
+      this.portalStatusBarIndicator.showPopover()
+      await authenticationProvider.signOut()
+    }
+  }
+
   async isSignedIn () {
     const authenticationProvider = await this.getAuthenticationProvider()
     if (authenticationProvider) {
@@ -167,7 +178,8 @@ class TeletypePackage {
           resolve(new AuthenticationProvider({
             client,
             credentialCache: this.credentialCache,
-            notificationManager: this.notificationManager
+            notificationManager: this.notificationManager,
+            workspace: this.workspace
           }))
         } else {
           this.authenticationProviderPromise = null


### PR DESCRIPTION
Closes #194 

This pull-request introduces a new `Sign out` command that allows users to sign out from Teletype (note how the user stays signed out even after reloading Atom):

<p align="center"><img src="https://user-images.githubusercontent.com/482957/33021430-22864c06-ce02-11e7-9ae8-e1530db856f8.gif"/></p>

Considering how infrequent this action is, I think we can avoid providing a graphical affordance for it in the popover and just have a simple command. Such command will be shown to users only when they have effectively signed in.

/cc: @nathansobo @jasonrudolph 