### PR TITLE
Refactor `GuestPortalBinding.setActiveEditorProxy(editorProxy)`

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -60,30 +60,35 @@ class GuestPortalBinding {
       if (editorProxy == null) {
         await this.replaceActivePaneItem(this.getEmptyPortalPaneItem())
       } else {
-        const {bufferProxy} = editorProxy
-        let editor
-        let editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-        if (editorBinding) {
-          editor = editorBinding.editor
-        } else {
-          const buffer = this.findOrCreateBufferForBufferProxy(bufferProxy)
-          editor = new TextEditor({buffer, autoHeight: false})
-          editorBinding = new EditorBinding({
-            editor,
-            portal: this.portal,
-            isHost: false,
-            didDispose: () => this.editorBindingsByEditorProxy.delete(editorProxy)
-          })
-          editorBinding.setEditorProxy(editorProxy)
-          editorProxy.setDelegate(editorBinding)
-          this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
-        }
-
+        const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
         await this.replaceActivePaneItem(editor)
       }
     })
 
     return this.lastSetActiveEditorProxyPromise
+  }
+
+  // Private
+  findOrCreateEditorForEditorProxy (editorProxy) {
+    let editor
+    let editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+    if (editorBinding) {
+      editor = editorBinding.editor
+    } else {
+      const {bufferProxy} = editorProxy
+      const buffer = this.findOrCreateBufferForBufferProxy(bufferProxy)
+      editor = new TextEditor({buffer, autoHeight: false})
+      editorBinding = new EditorBinding({
+        editor,
+        portal: this.portal,
+        isHost: false,
+        didDispose: () => this.editorBindingsByEditorProxy.delete(editorProxy)
+      })
+      editorBinding.setEditorProxy(editorProxy)
+      editorProxy.setDelegate(editorBinding)
+      this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
+    }
+    return editor
   }
 
   // Private

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -14,7 +14,6 @@ class GuestPortalBinding {
     this.notificationManager = notificationManager
     this.emitDidDispose = didDispose
     this.activePaneItem = null
-    this.activeEditorBinding = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
     this.addedPaneItems = new WeakSet()
@@ -94,7 +93,6 @@ class GuestPortalBinding {
           this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
         }
 
-        this.activeEditorBinding = editorBinding
         await this.replaceActivePaneItem(editor)
       }
     })

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -63,24 +63,10 @@ class GuestPortalBinding {
         const {bufferProxy} = editorProxy
         let editor
         let editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-        let bufferBinding = this.bufferBindingsByBufferProxy.get(bufferProxy)
         if (editorBinding) {
           editor = editorBinding.editor
         } else {
-          let buffer
-          if (bufferBinding) {
-            buffer = bufferBinding.buffer
-          } else {
-            buffer = new TextBuffer()
-            bufferBinding = new BufferBinding({
-              buffer,
-              didDispose: () => this.bufferBindingsByBufferProxy.delete(bufferProxy)
-            })
-            bufferBinding.setBufferProxy(bufferProxy)
-            bufferProxy.setDelegate(bufferBinding)
-            this.bufferBindingsByBufferProxy.set(bufferProxy, bufferBinding)
-          }
-
+          const buffer = this.findOrCreateBufferForBufferProxy(bufferProxy)
           editor = new TextEditor({buffer, autoHeight: false})
           editorBinding = new EditorBinding({
             editor,
@@ -98,6 +84,25 @@ class GuestPortalBinding {
     })
 
     return this.lastSetActiveEditorProxyPromise
+  }
+
+  // Private
+  findOrCreateBufferForBufferProxy (bufferProxy) {
+    let buffer
+    let bufferBinding = this.bufferBindingsByBufferProxy.get(bufferProxy)
+    if (bufferBinding) {
+      buffer = bufferBinding.buffer
+    } else {
+      buffer = new TextBuffer()
+      bufferBinding = new BufferBinding({
+        buffer,
+        didDispose: () => this.bufferBindingsByBufferProxy.delete(bufferProxy)
+      })
+      bufferBinding.setBufferProxy(bufferProxy)
+      bufferProxy.setDelegate(bufferBinding)
+      this.bufferBindingsByBufferProxy.set(bufferProxy, bufferBinding)
+    }
+    return buffer
   }
 
   activate () {


### PR DESCRIPTION
This pull request refactors `GuestPortalBinding.setActiveEditorProxy(editorProxy)` into a [Composed Method](http://don.fed.wiki.org/view/composed-method) (i.e., such that all operations in the method are at the same level of abstraction).
