### PR TITLE
👕  Set up Standard JS linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ addons:
 before_script:
   - createdb teletype-test
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+# TODO: Once https://github.com/atom/ci/pull/79 is merged, update URL below to use build-package.sh on master branch
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/a5ca10c32676334605be6492369327056e6692b0/build-package.sh | sh'
 
 git:
   depth: 10

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = new TeletypePackage({
   clipboard: atom.clipboard,
   pusherKey: atom.config.get('teletype.pusherKey'),
   pusherOptions: {
-    cluster: atom.config.get('teletype.pusherCluster'),
+    cluster: atom.config.get('teletype.pusherCluster')
   },
   baseURL: atom.config.get('teletype.baseURL')
 })

--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -1,4 +1,4 @@
-const {Point, Range} = require('atom')
+const {Range} = require('atom')
 
 function doNothing () {}
 

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -1,3 +1,5 @@
+/* global ResizeObserver */
+
 const path = require('path')
 const {Range, Disposable, CompositeDisposable} = require('atom')
 const normalizeURI = require('./normalize-uri')

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -304,10 +304,6 @@ class EditorBinding {
   }
 }
 
-function isHost (siteId) {
-  return siteId === 1
-}
-
 function getSelectionState (marker) {
   return {
     range: marker.getRange(),

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -316,7 +316,7 @@ function getSelectionState (marker) {
   }
 }
 
-function cursorClassForSiteId (siteId, {blink}={}) {
+function cursorClassForSiteId (siteId, {blink} = {}) {
   let className = 'ParticipantCursor--site-' + siteId
   if (blink === false) className += ' non-blinking'
   return className

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -1,4 +1,4 @@
-const {CompositeDisposable, Emitter, TextEditor, TextBuffer} = require('atom')
+const {Emitter, TextEditor, TextBuffer} = require('atom')
 const {Errors} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -2,7 +2,6 @@ const {Emitter, TextEditor, TextBuffer} = require('atom')
 const {Errors} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
-const GuestPortalBinding = require('./guest-portal-binding')
 const EmptyPortalPaneItem = require('./empty-portal-pane-item')
 
 module.exports =

--- a/lib/popover-component.js
+++ b/lib/popover-component.js
@@ -23,7 +23,7 @@ class PopoverComponent {
     const {
       isClientOutdated, initializationError,
       authenticationProvider, portalBindingManager,
-      commandRegistry, credentialCache, clipboard, workspace, notificationManager
+      commandRegistry, clipboard, workspace, notificationManager
     } = this.props
 
     let activeComponent

--- a/lib/portal-binding-manager.js
+++ b/lib/portal-binding-manager.js
@@ -108,7 +108,7 @@ class PortalBindingManager {
 
   async getActiveGuestPortalBinding () {
     const activePaneItem = this.workspace.getActivePaneItem()
-    for (const [_, portalBindingPromise] of this.promisesByGuestPortalId) {
+    for (const [_, portalBindingPromise] of this.promisesByGuestPortalId) { // eslint-disable-line no-unused-vars
       const portalBinding = await portalBindingPromise
       if (portalBinding.getActivePaneItem() === activePaneItem) {
         return portalBinding

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "index.js",
   "repository": "https://github.com/atom/teletype",
   "scripts": {
+    "lint": "standard --verbose",
     "test": "atom --test test"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
       "mocha": true
     },
     "globals": [
-      "atom"
+      "atom",
+      "ErrorEvent"
     ],
     "ignore": ["test/fixtures"]
   }

--- a/package.json
+++ b/package.json
@@ -62,14 +62,11 @@
     }
   },
   "standard": {
+    "env": {
+      "mocha": true
+    },
     "globals": [
-      "atom",
-      "setup",
-      "suite",
-      "suiteSetup",
-      "suiteTeardown",
-      "teardown",
-      "test"
+      "atom"
     ],
     "ignore": ["test/fixtures"]
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@atom/teletype-server": "^0.17.0",
     "atom-mocha-test-runner": "^1.0.1",
     "deep-equal": "^1.0.1",
+    "standard": "^10.0.3",
     "temp": "^0.8.3"
   },
   "dependencies": {
@@ -58,5 +59,17 @@
       "default": "mt1",
       "order": 3
     }
+  },
+  "standard": {
+    "globals": [
+      "atom",
+      "setup",
+      "suite",
+      "suiteSetup",
+      "suiteTeardown",
+      "teardown",
+      "test"
+    ],
+    "ignore": ["test/fixtures"]
   }
 }

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -487,7 +487,7 @@ suite('EditorBinding', function () {
     const {decorationManager} = editor
     const decorationsByMarker = decorationManager.decorationPropertiesByMarkerForScreenRowRange(0, Infinity)
     const cursorDecorations = []
-    for (const [marker, decorations] of decorationsByMarker) {
+    for (const [marker, decorations] of decorationsByMarker) { // eslint-disable-line no-unused-vars
       let className = ''
       for (const decoration of decorations) {
         if (decoration.type === 'cursor' && decoration.class) {

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -377,7 +377,7 @@ suite('EditorBinding', function () {
       2: {row: 9, column: 5}, // collaborator below visible area
       3: {row: 6, column: 1}, // collaborator to the left of visible area
       4: {row: 6, column: 15}, // collaborator to the right of visible area
-      5: {row: 6, column: 6}, // collaborator inside of visible area
+      5: {row: 6, column: 6} // collaborator inside of visible area
     })
 
     assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -37,7 +37,7 @@ suite('EditorBinding', function () {
   teardown(async () => {
     if (!global.debugContent) {
       let element
-      while (element = attachedElements.pop()) {
+      while (element = attachedElements.pop()) { // eslint-disable-line no-cond-assign
         element.remove()
       }
 

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -158,14 +158,13 @@ suite('EditorBinding', function () {
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
-    const originalLocalSelection = {start: {row: 0, column: 0}, end: {row: 0, column: 0}}
     const originalRemoteSelection = {start: {row: 1, column: 0}, end: {row: 1, column: 5}}
     binding.updateSelectionsForSiteId(2, {1: {range: originalRemoteSelection}})
     assert.deepEqual(
       getCursorDecoratedRanges(editor),
       [
-        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}},
-        {tail: {row: 1, column: 0}, head: {row: 1, column: 5}}
+        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}}, // local selection
+        {tail: {row: 1, column: 0}, head: {row: 1, column: 5}}  // remote selection
       ]
     )
 
@@ -175,18 +174,17 @@ suite('EditorBinding', function () {
     assert.deepEqual(
       getCursorDecoratedRanges(editor),
       [
-        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}},
-        {tail: {row: 1, column: 0}, head: {row: 1, column: 0}}
+        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}}, // local selection
+        {tail: {row: 1, column: 0}, head: {row: 1, column: 0}}  // remote selection
       ]
     )
 
     editor.getBuffer().setTextInRange([remoteSelectionAfterDelete.start, remoteSelectionAfterDelete.start], 'a', {undo: 'skip'})
-    const remoteSelectionAfterInsert = {start: {row: 1, column: 1}, end: {row: 1, column: 1}}
     assert.deepEqual(
       getCursorDecoratedRanges(editor),
       [
-        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}},
-        {tail: {row: 1, column: 1}, head: {row: 1, column: 1}}
+        {tail: {row: 0, column: 0}, head: {row: 0, column: 0}}, // local selection
+        {tail: {row: 1, column: 1}, head: {row: 1, column: 1}}  // remote selection
       ]
     )
   })

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -36,6 +36,7 @@ suite('EditorBinding', function () {
 
   teardown(async () => {
     if (!global.debugContent) {
+      let element
       while (element = attachedElements.pop()) {
         element.remove()
       }

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const etch = require('etch')
 const condition = require('./helpers/condition')
 const {Disposable} = require('atom')
 const FakeClipboard = require('./helpers/fake-clipboard')

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -87,7 +87,7 @@ suite('PortalListComponent', function () {
   })
 
   test('joining portals', async () => {
-    const {component, portalBindingManager} = await buildComponent()
+    const {component} = await buildComponent()
     const {joinPortalComponent, guestPortalBindingsContainer} = component.refs
 
     assert(joinPortalComponent.refs.joinPortalLabel)

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -87,7 +87,7 @@ suite('PortalListComponent', function () {
   })
 
   test('joining portals', async () => {
-    const {component, element, portalBindingManager} = await buildComponent()
+    const {component, portalBindingManager} = await buildComponent()
     const {joinPortalComponent, guestPortalBindingsContainer} = component.refs
 
     assert(joinPortalComponent.refs.joinPortalLabel)

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -307,7 +307,7 @@ suite('TeletypePackage', function () {
   })
 
   test('indicating portal status via status bar icon', async () => {
-    isTransmitting = function (statusBar) {
+    const isTransmitting = function (statusBar) {
       return statusBar.getRightTiles()[0].item.element.classList.contains('transmitting')
     }
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -22,9 +22,9 @@ suite('TeletypePackage', function () {
   suiteSetup(async function () {
     const {startTestServer} = require('@atom/teletype-server')
     testServer = await startTestServer({
-      databaseURL: 'postgres://localhost:5432/teletype-test',
+      databaseURL: 'postgres://localhost:5432/teletype-test'
       // Uncomment and provide credentials to test against Pusher.
-      // pusherCredentials: {
+      // , pusherCredentials: {
       //   appId: '123',
       //   key: '123',
       //   secret: '123'

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -17,7 +17,7 @@ const temp = require('temp').track()
 suite('TeletypePackage', function () {
   this.timeout(process.env.TEST_TIMEOUT_IN_MS || 5000)
 
-  let testServer, containerElement, packages, portals
+  let testServer, containerElement, packages
 
   suiteSetup(async function () {
     const {startTestServer} = require('@atom/teletype-server')

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -17,7 +17,7 @@ const temp = require('temp').track()
 suite('TeletypePackage', function () {
   this.timeout(process.env.TEST_TIMEOUT_IN_MS || 5000)
 
-  let testServer, containerElement, environments, packages, portals
+  let testServer, containerElement, packages, portals
 
   suiteSetup(async function () {
     const {startTestServer} = require('@atom/teletype-server')

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -848,7 +848,7 @@ suite('TeletypePackage', function () {
   test('adding and removing workspace element classes when sharing a portal', async () => {
     const host1Env = buildAtomEnvironment()
     const host1Package = await buildPackage(host1Env)
-    const host1Portal = await host1Package.sharePortal()
+    await host1Package.sharePortal()
     assert(host1Env.workspace.getElement().classList.contains('teletype-Host'))
     await host1Package.closeHostPortal()
     assert(!host1Env.workspace.getElement().classList.contains('teletype-Host'))

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -366,12 +366,12 @@ suite('TeletypePackage', function () {
 
     const portal = await hostPackage.sharePortal()
     await guestPackage.joinPortal(portal.id)
-    const hostEditor1 = await hostEnv.workspace.open(path.join(temp.path(), 'host-1'))
+    await hostEnv.workspace.open(path.join(temp.path(), 'host-1'))
     const guestRemoteEditor1 = await getNextRemotePaneItemPromise(guestEnv)
     const guestLocalEditor2 = await guestEnv.workspace.open(path.join(temp.path(), 'guest-2'))
     assert.deepEqual(getPaneItems(guestEnv), [guestLocalEditor1, guestRemoteEditor1, guestLocalEditor2])
 
-    const hostEditor2 = await hostEnv.workspace.open(path.join(temp.path(), 'host-2'))
+    await hostEnv.workspace.open(path.join(temp.path(), 'host-2'))
     const guestRemoteEditor2 = await getNextRemotePaneItemPromise(guestEnv)
 
     assert.deepEqual(getPaneItems(guestEnv), [guestLocalEditor1, guestRemoteEditor2, guestLocalEditor2])

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -346,11 +346,11 @@ suite('TeletypePackage', function () {
   })
 
   test('attempting to join a nonexistent portal', async () => {
-    const guestPackage = await buildPackage(buildAtomEnvironment())
+    const pack = await buildPackage(buildAtomEnvironment())
     const notifications = []
-    guestPackage.notificationManager.onDidAddNotification((n) => notifications.push(n))
+    pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
-    await guestPackage.joinPortal('some-nonexistent-portal-id')
+    await pack.joinPortal('some-nonexistent-portal-id')
     const errorNotification = notifications.find((n) => n.message === 'Portal not found')
     assert(errorNotification, 'Expected notifications to include "Portal not found" error')
   })

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -350,7 +350,7 @@ suite('TeletypePackage', function () {
     const notifications = []
     guestPackage.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
-    const guestPortal = await guestPackage.joinPortal('some-nonexistent-portal-id')
+    await guestPackage.joinPortal('some-nonexistent-portal-id')
     const errorNotification = notifications.find((n) => n.message === 'Portal not found')
     assert(errorNotification, 'Expected notifications to include "Portal not found" error')
   })

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -846,12 +846,12 @@ suite('TeletypePackage', function () {
   })
 
   test('adding and removing workspace element classes when sharing a portal', async () => {
-    const host1Env = buildAtomEnvironment()
-    const host1Package = await buildPackage(host1Env)
-    await host1Package.sharePortal()
-    assert(host1Env.workspace.getElement().classList.contains('teletype-Host'))
-    await host1Package.closeHostPortal()
-    assert(!host1Env.workspace.getElement().classList.contains('teletype-Host'))
+    const hostEnv = buildAtomEnvironment()
+    const hostPackage = await buildPackage(hostEnv)
+    await hostPackage.sharePortal()
+    assert(hostEnv.workspace.getElement().classList.contains('teletype-Host'))
+    await hostPackage.closeHostPortal()
+    assert(!hostEnv.workspace.getElement().classList.contains('teletype-Host'))
   })
 
   test('reports when the package needs to be upgraded due to an out-of-date protocol version', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -995,7 +995,7 @@ suite('TeletypePackage', function () {
 
   async function getNextActiveTextEditorPromise ({workspace}) {
     const currentEditor = workspace.getActiveTextEditor()
-    await condition(() => workspace.getActiveTextEditor() != currentEditor)
+    await condition(() => workspace.getActiveTextEditor() !== currentEditor)
     return workspace.getActiveTextEditor()
   }
 


### PR DESCRIPTION
Configure linter for [JavaScript Standard Style](https://standardjs.com) to foster consistency with the [Atom style guide](https://github.com/atom/atom/blob/572aec74d9fb612849a2b02cb5e54d515341c0fd/CONTRIBUTING.md#javascript-styleguide).

### TODO

- [x] Set up [JavaScript Standard Style](https://standardjs.com) linter
- [x] Resolve existing linter violations
