### PR TITLE
Allow guests to collaborate on multiple remote buffers (Part 1)

### DIFF
--- a/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
+++ b/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
@@ -32,7 +32,12 @@ When a host closes a buffer, it will be removed from all guest portals. If anoth
 
 You can follow any other guest participating in the host's workspace in the exact same way. If they move between buffers, you will follow them. The host does not enjoy any special privilege with respect to the ability to be followed between different files.
 
-When a participant is viewing a different buffer than you are viewing, that participant's avatar appears in the bottom right with an icon (e.g., https://octicons.github.com/icon/link-external) indicating that they're working on a different buffer.
+When viewing an editor associated with a portal, each participant sees the avatars for the other portal participants (just as they did prior to this RFC). As a host, when your active pane item is a local editor (i.e., an editor that you're sharing in your portal), the editor shows the avatars for the other portal participants. As a guest, when your active pane item is a remote editor (i.e., an editor that you're viewing from the host's portal), the editor shows the avatars for the other portal participants. The location of each avatar within the editor indicates the relative position of that participant:
+- Top-right: Participants in the same editor but in a row above your viewport
+- Middle-right: Participants in the same editor and inside your viewport
+- Bottom-right: Participants in the same editor but in a row below your viewport or a column outside of your viewport
+- Bottom-right with TBD icon 1: Participants in a different editor in the portal
+- Bottom-right with TBD icon 2: Participants in a different pane item not associated with the portal
 
 Editors for remote buffers are *only* automatically opened when you are following another collaborator. If you are not following someone, no editors are automatically opened. When you start following another collaborator again, an editor will be automatically opened based on their location. You can also open any buffer in the host's workspace directly by navigating to it...
 

--- a/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
+++ b/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-This is a proposal and is not yet implemented.
+This is a proposal and is not yet fully implemented.
+
+[#262](https://github.com/atom/teletype/pull/262) implements the majority of this proposal, and the remaining functionality is planned for future pull requests. See [#262](https://github.com/atom/teletype/pull/262) for details.
 
 ## Summary
 

--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -4,13 +4,18 @@ function doNothing () {}
 
 module.exports =
 class BufferBinding {
-  constructor ({buffer, didDispose}) {
+  constructor ({buffer, isHost, didDispose}) {
     this.buffer = buffer
+    this.isHost = isHost
     this.emitDidDispose = didDispose || doNothing
     this.pendingChanges = []
+    this.disposed = false
   }
 
   dispose () {
+    if (this.disposed) return
+
+    this.disposed = true
     this.buffer.restoreDefaultHistoryProvider(this.bufferProxy.getHistory(this.buffer.maxUndoEntries))
     this.buffer = null
     if (this.bufferDestroySubscription) this.bufferDestroySubscription.dispose()
@@ -24,7 +29,13 @@ class BufferBinding {
       this.pushChange(this.pendingChanges.shift())
     }
     this.pendingChanges = null
-    this.bufferDestroySubscription = this.buffer.onDidDestroy(() => bufferProxy.dispose())
+    this.bufferDestroySubscription = this.buffer.onDidDestroy(() => {
+      if (this.isHost) {
+        bufferProxy.dispose()
+      } else {
+        this.dispose()
+      }
+    })
   }
 
   setText (text) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -59,7 +59,7 @@ class EditorBinding {
     this.subscriptions.add(this.editor.element.onDidChangeScrollTop(this.editorDidChangeScrollTop.bind(this)))
     this.subscriptions.add(this.editor.element.onDidChangeScrollLeft(this.editorDidChangeScrollLeft.bind(this)))
     this.subscriptions.add(subscribeToResizeEvents(this.editor.element, this.editorDidResize.bind(this)))
-    this.relayLocalSelections(true)
+    this.relayLocalSelections()
 
     this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
     this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
@@ -280,14 +280,15 @@ class EditorBinding {
     this.markersByLayerAndId.delete(markerLayer)
   }
 
-  relayLocalSelections (initialUpdate = false) {
+  relayLocalSelections () {
     const selectionUpdates = {}
     const selectionMarkers = this.selectionsMarkerLayer.getMarkers()
     for (let i = 0; i < selectionMarkers.length; i++) {
       const marker = selectionMarkers[i]
       selectionUpdates[marker.id] = getSelectionState(marker)
     }
-    this.editorProxy.updateSelections(selectionUpdates, initialUpdate)
+    this.updateSelections(selectionUpdates, {initialUpdate: true})
+  }
 
   batchMarkerUpdates (fn) {
     this.batchedMarkerUpdates = {}

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -106,14 +106,14 @@ class EditorBinding {
     editor.emitter.emit('did-change-title', editor.getTitle())
   }
 
-  observeMarker (marker, relayLocalSelections = true) {
+  observeMarker (marker, relay = true) {
     const didChangeDisposable = marker.onDidChange(({textChanged}) => {
       if (textChanged) {
         if (marker.getRange().isEmpty()) marker.clearTail()
       } else {
-        this.editorProxy.updateSelections({
+        this.updateSelections({
           [marker.id]: getSelectionState(marker)
-        }, this.preserveFollowState)
+        })
       }
     })
     const didDestroyDisposable = marker.onDidDestroy(() => {
@@ -122,13 +122,18 @@ class EditorBinding {
       this.subscriptions.remove(didChangeDisposable)
       this.subscriptions.remove(didDestroyDisposable)
 
-      this.editorProxy.updateSelections({
+      this.updateSelections({
         [marker.id]: null
-      }, this.preserveFollowState)
+      })
     })
     this.subscriptions.add(didChangeDisposable)
     this.subscriptions.add(didDestroyDisposable)
-    if (relayLocalSelections) this.relayLocalSelections()
+
+    if (relay) {
+      this.updateSelections({
+        [marker.id]: getSelectionState(marker)
+      })
+    }
   }
 
   async editorDidChangeScrollTop () {
@@ -207,10 +212,7 @@ class EditorBinding {
 
     if (state === FollowState.RETRACTED) {
       this.editor.destroyFoldsIntersectingBufferRange(Range(position, position))
-
-      this.preserveFollowState = true
-      this.editor.setCursorBufferPosition(position)
-      this.preserveFollowState = false
+      this.batchMarkerUpdates(() => this.editor.setCursorBufferPosition(position))
 
       localCursorDecorationProperties.style = {opacity: 0}
     } else {
@@ -286,6 +288,22 @@ class EditorBinding {
       selectionUpdates[marker.id] = getSelectionState(marker)
     }
     this.editorProxy.updateSelections(selectionUpdates, initialUpdate)
+
+  batchMarkerUpdates (fn) {
+    this.batchedMarkerUpdates = {}
+    this.isBatchingMarkerUpdates = true
+    fn()
+    this.isBatchingMarkerUpdates = false
+    this.editorProxy.updateSelections(this.batchedMarkerUpdates)
+    this.batchedMarkerUpdates = null
+  }
+
+  updateSelections (update) {
+    if (this.isBatchingMarkerUpdates) {
+      Object.assign(this.batchedMarkerUpdates, update)
+    } else {
+      this.editorProxy.updateSelections(update)
+    }
   }
 
   buildSitePositionsComponent (position) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -21,6 +21,9 @@ class EditorBinding {
   }
 
   dispose () {
+    if (this.disposed) return
+
+    this.disposed = true
     this.subscriptions.dispose()
 
     this.markerLayersBySiteId.forEach((l) => l.destroy())
@@ -68,9 +71,13 @@ class EditorBinding {
     editor.copy = () => null
     editor.serialize = () => null
     editor.isRemote = true
+
+    let remoteEditorCountForBuffer = buffer.remoteEditorCount || 0
+    buffer.remoteEditorCount = ++remoteEditorCountForBuffer
     buffer.getPath = () => `${uriPrefix}:${bufferURI}`
     buffer.save = () => {}
     buffer.isModified = () => false
+
     editor.element.classList.add('teletype-RemotePaneItem')
   }
 
@@ -84,9 +91,14 @@ class EditorBinding {
     delete editor.copy
     delete editor.serialize
     delete editor.isRemote
-    delete buffer.getPath
-    delete buffer.save
-    delete buffer.isModified
+
+    buffer.remoteEditorCount--
+    if (buffer.remoteEditorCount === 0) {
+      delete buffer.remoteEditorCount
+      delete buffer.getPath
+      delete buffer.save
+      delete buffer.isModified
+    }
 
     editor.element.classList.remove('teletype-RemotePaneItem')
     editor.emitter.emit('did-change-title', editor.getTitle())

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -289,7 +289,7 @@ class EditorBinding {
       const marker = selectionMarkers[i]
       selectionUpdates[marker.id] = getSelectionState(marker)
     }
-    this.updateSelections(selectionUpdates, {initialUpdate: true})
+    this.editorProxy.updateSelections(selectionUpdates, {initialUpdate: true})
   }
 
   batchMarkerUpdates (fn) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -4,7 +4,6 @@ const path = require('path')
 const {Range, Emitter, Disposable, CompositeDisposable} = require('atom')
 const normalizeURI = require('./normalize-uri')
 const {FollowState} = require('@atom/teletype-client')
-const SitePositionsComponent = require('./site-positions-component')
 
 function doNothing () {}
 
@@ -34,10 +33,6 @@ class EditorBinding {
     if (!this.isHost) this.restoreOriginalEditorMethods(this.editor)
     if (this.localCursorLayerDecoration) this.localCursorLayerDecoration.destroy()
 
-    this.aboveViewportSitePositionsComponent.destroy()
-    this.insideViewportSitePositionsComponent.destroy()
-    this.outsideViewportSitePositionsComponent.destroy()
-
     this.emitDidDispose()
   }
 
@@ -63,14 +58,6 @@ class EditorBinding {
     this.subscriptions.add(this.editor.element.onDidChangeScrollLeft(this.editorDidChangeScrollLeft.bind(this)))
     this.subscriptions.add(subscribeToResizeEvents(this.editor.element, this.editorDidResize.bind(this)))
     this.relayLocalSelections()
-
-    this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
-    this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
-    this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
-
-    this.editor.element.appendChild(this.aboveViewportSitePositionsComponent.element)
-    this.editor.element.appendChild(this.insideViewportSitePositionsComponent.element)
-    this.editor.element.appendChild(this.outsideViewportSitePositionsComponent.element)
   }
 
   monkeyPatchEditorMethods (editor, editorProxy) {
@@ -227,36 +214,6 @@ class EditorBinding {
     this.localCursorLayerDecoration.setProperties(localCursorDecorationProperties)
   }
 
-  updateActivePositions (positionsBySiteId) {
-    const aboveViewportSiteIds = []
-    const insideViewportSiteIds = []
-    const outsideViewportSiteIds = []
-    const followedSiteId = this.editorProxy.getFollowedSiteId()
-
-    for (let siteId in positionsBySiteId) {
-      siteId = parseInt(siteId)
-      const position = positionsBySiteId[siteId]
-      switch (this.getDirectionFromViewportToPosition(position)) {
-        case 'upward':
-          aboveViewportSiteIds.push(siteId)
-          break
-        case 'inside':
-          insideViewportSiteIds.push(siteId)
-          break
-        case 'downward':
-        case 'leftward':
-        case 'rightward':
-          outsideViewportSiteIds.push(siteId)
-          break
-      }
-    }
-
-    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
-    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
-    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})
-    this.positionsBySiteId = positionsBySiteId
-  }
-
   getDirectionFromViewportToPosition (bufferPosition) {
     const {element} = this.editor
     if (!document.contains(element)) return
@@ -310,15 +267,6 @@ class EditorBinding {
     } else {
       this.editorProxy.updateSelections(update)
     }
-  }
-
-  buildSitePositionsComponent (position) {
-    return new SitePositionsComponent({
-      position,
-      displayedParticipantsCount: 3,
-      portal: this.portal,
-      onSelectSiteId: this.toggleFollowingForSiteId.bind(this)
-    })
   }
 
   toggleFollowingForSiteId (siteId) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -203,8 +203,10 @@ class EditorBinding {
     }
   }
 
-  isPositionVisible (bufferPosition) {
-    return this.getDirectionFromViewportToPosition(bufferPosition) === 'inside'
+  isScrollNeededToViewPosition (position) {
+    const isPositionVisible = this.getDirectionFromViewportToPosition(position) === 'inside'
+    const isEditorAttachedToDOM = document.body.contains(this.editor.element)
+    return isEditorAttachedToDOM && !isPositionVisible
   }
 
   updateTether (state, position) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -41,6 +41,7 @@ class EditorBinding {
       this.editor.onDidDestroy(() => this.editorProxy.dispose())
     } else {
       this.monkeyPatchEditorMethods(this.editor, this.editorProxy)
+      this.editor.onDidDestroy(() => this.dispose())
     }
 
     this.localCursorLayerDecoration = this.editor.decorateMarkerLayer(

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -5,8 +5,6 @@ const {Range, Emitter, Disposable, CompositeDisposable} = require('atom')
 const normalizeURI = require('./normalize-uri')
 const {FollowState} = require('@atom/teletype-client')
 
-function doNothing () {}
-
 module.exports =
 class EditorBinding {
   constructor ({editor, portal, isHost}) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -1,7 +1,7 @@
 /* global ResizeObserver */
 
 const path = require('path')
-const {Range, Disposable, CompositeDisposable} = require('atom')
+const {Range, Emitter, Disposable, CompositeDisposable} = require('atom')
 const normalizeURI = require('./normalize-uri')
 const {FollowState} = require('@atom/teletype-client')
 const SitePositionsComponent = require('./site-positions-component')
@@ -10,10 +10,13 @@ function doNothing () {}
 
 module.exports =
 class EditorBinding {
-  constructor ({editor, portal, isHost, didDispose}) {
+  constructor ({editor, portal, isHost, didResize, didScroll, didDispose}) {
     this.editor = editor
     this.portal = portal
     this.isHost = isHost
+    this.emitter = new Emitter()
+    this.emitDidResize = didResize || doNothing
+    this.emitDidScroll = didScroll || doNothing
     this.emitDidDispose = didDispose || doNothing
     this.selectionsMarkerLayer = this.editor.selectionsMarkerLayer.bufferMarkerLayer
     this.markerLayersBySiteId = new Map()
@@ -139,24 +142,21 @@ class EditorBinding {
   async editorDidChangeScrollTop () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    // TODO: move into portal bindings.
-    // this.updateActivePositions(this.positionsBySiteId)
     this.editorProxy.didScroll()
+    this.emitDidScroll()
   }
 
   async editorDidChangeScrollLeft () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    // TODO: move into portal bindings.
-    // this.updateActivePositions(this.positionsBySiteId)
     this.editorProxy.didScroll()
+    this.emitDidScroll()
   }
 
   async editorDidResize () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    // TODO: move into portal bindings.
-    // this.updateActivePositions(this.positionsBySiteId)
+    this.emitDidResize()
   }
 
   updateSelectionsForSiteId (siteId, selections) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -139,21 +139,24 @@ class EditorBinding {
   async editorDidChangeScrollTop () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    this.updateActivePositions(this.positionsBySiteId)
+    // TODO: move into portal bindings.
+    // this.updateActivePositions(this.positionsBySiteId)
     this.editorProxy.didScroll()
   }
 
   async editorDidChangeScrollLeft () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    this.updateActivePositions(this.positionsBySiteId)
+    // TODO: move into portal bindings.
+    // this.updateActivePositions(this.positionsBySiteId)
     this.editorProxy.didScroll()
   }
 
   async editorDidResize () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    this.updateActivePositions(this.positionsBySiteId)
+    // TODO: move into portal bindings.
+    // this.updateActivePositions(this.positionsBySiteId)
   }
 
   updateSelectionsForSiteId (siteId, selections) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -9,14 +9,11 @@ function doNothing () {}
 
 module.exports =
 class EditorBinding {
-  constructor ({editor, portal, isHost, didResize, didScroll, didDispose}) {
+  constructor ({editor, portal, isHost}) {
     this.editor = editor
     this.portal = portal
     this.isHost = isHost
     this.emitter = new Emitter()
-    this.emitDidResize = didResize || doNothing
-    this.emitDidScroll = didScroll || doNothing
-    this.emitDidDispose = didDispose || doNothing
     this.selectionsMarkerLayer = this.editor.selectionsMarkerLayer.bufferMarkerLayer
     this.markerLayersBySiteId = new Map()
     this.markersByLayerAndId = new WeakMap()
@@ -33,7 +30,8 @@ class EditorBinding {
     if (!this.isHost) this.restoreOriginalEditorMethods(this.editor)
     if (this.localCursorLayerDecoration) this.localCursorLayerDecoration.destroy()
 
-    this.emitDidDispose()
+    this.emitter.emit('did-dispose')
+    this.emitter.dispose()
   }
 
   setEditorProxy (editorProxy) {
@@ -130,20 +128,32 @@ class EditorBinding {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
     this.editorProxy.didScroll()
-    this.emitDidScroll()
+    this.emitter.emit('did-scroll')
   }
 
   async editorDidChangeScrollLeft () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
     this.editorProxy.didScroll()
-    this.emitDidScroll()
+    this.emitter.emit('did-scroll')
   }
 
   async editorDidResize () {
     const {element} = this.editor
     await element.component.getNextUpdatePromise()
-    this.emitDidResize()
+    this.emitter.emit('did-resize')
+  }
+
+  onDidDispose (callback) {
+    return this.emitter.on('did-dispose', callback)
+  }
+
+  onDidScroll (callback) {
+    return this.emitter.on('did-scroll', callback)
+  }
+
+  onDidResize (callback) {
+    return this.emitter.on('did-resize', callback)
   }
 
   updateSelectionsForSiteId (siteId, selections) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -187,14 +187,6 @@ class GuestPortalBinding {
     this.newActivePaneItem = null
   }
 
-  // Private
-  shouldShowEmptyPortalPaneItem () {
-    return (
-      this.getActivePaneItem() !== this.getEmptyPortalPaneItem() &&
-      this.editorBindingsByEditorProxy.size === 0
-    )
-  }
-
   getActivePaneItem () {
     return this.newActivePaneItem ? this.newActivePaneItem : this.activePaneItem
   }

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -15,9 +15,9 @@ class GuestPortalBinding {
     this.activePaneItem = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
-    this.addedPaneItems = new WeakSet()
     this.emitter = new Emitter()
-    this.lastSetActiveEditorProxyPromise = Promise.resolve()
+    this.lastEditorProxyChangePromise = Promise.resolve()
+    this.openEditorProxies = new Set()
   }
 
   async initialize () {
@@ -25,7 +25,11 @@ class GuestPortalBinding {
       this.portal = await this.client.joinPortal(this.portalId)
       if (!this.portal) return false
 
-      this.portal.setDelegate(this)
+      await this.portal.setDelegate(this)
+      if (this.openEditorProxies.size === 0) {
+        await this.openPaneItem(this.getEmptyPortalPaneItem())
+      }
+
       return true
     } catch (error) {
       this.didFailToJoin(error)
@@ -34,8 +38,7 @@ class GuestPortalBinding {
   }
 
   dispose () {
-    if (this.activePaneItemDestroySubscription) this.activePaneItemDestroySubscription.dispose()
-    if (this.activePaneItem) this.activePaneItem.destroy()
+    this.openEditorProxies.clear()
     if (this.emptyPortalItem) this.emptyPortalItem.destroy()
     this.emitDidDispose()
   }
@@ -54,17 +57,32 @@ class GuestPortalBinding {
     this.emitter.emit('did-change')
   }
 
-  async setActiveEditorProxy (editorProxy) {
-    this.lastSetActiveEditorProxyPromise = this.lastSetActiveEditorProxyPromise.then(async () => {
-      if (editorProxy == null) {
-        await this.replaceActivePaneItem(this.getEmptyPortalPaneItem())
-      } else {
-        const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
-        await this.replaceActivePaneItem(editor)
+  activateEditorProxy (editorProxy) {
+    this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
+      if (this.openEditorProxies.size === 0) {
+        this.getEmptyPortalPaneItem().destroy()
+      }
+      this.openEditorProxies.add(editorProxy)
+
+      const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
+      await this.openPaneItem(editor)
+    })
+
+    return this.lastEditorProxyChangePromise
+  }
+
+  removeEditorProxy (editorProxy) {
+    this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
+      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      editorBinding.editor.destroy()
+
+      this.openEditorProxies.delete(editorProxy)
+      if (this.openEditorProxies.size === 0) {
+        await this.openPaneItem(this.getEmptyPortalPaneItem())
       }
     })
 
-    return this.lastSetActiveEditorProxyPromise
+    return this.lastEditorProxyChangePromise
   }
 
   // Private
@@ -155,26 +173,26 @@ class GuestPortalBinding {
   }
 
   leave () {
+    this.editorBindingsByEditorProxy.forEach((binding) => {
+      binding.editor.destroy()
+    })
+
     if (this.portal) this.portal.dispose()
   }
 
-  async replaceActivePaneItem (newActivePaneItem) {
+  async openPaneItem (newActivePaneItem) {
     this.newActivePaneItem = newActivePaneItem
-
-    if (this.activePaneItem) {
-      const pane = this.workspace.paneForItem(this.activePaneItem)
-      const index = pane.getItems().indexOf(this.activePaneItem)
-      pane.addItem(newActivePaneItem, {index, moved: this.addedPaneItems.has(newActivePaneItem)})
-      pane.removeItem(this.activePaneItem)
-    } else {
-      await this.workspace.open(newActivePaneItem)
-    }
-    this.addedPaneItems.add(newActivePaneItem)
-
+    await this.workspace.open(newActivePaneItem)
     this.activePaneItem = this.newActivePaneItem
-    if (this.activePaneItemDestroySubscription) this.activePaneItemDestroySubscription.dispose()
-    this.activePaneItemDestroySubscription = this.activePaneItem.onDidDestroy(this.leave.bind(this))
     this.newActivePaneItem = null
+  }
+
+  // Private
+  shouldShowEmptyPortalPaneItem () {
+    return (
+      this.getActivePaneItem() !== this.getEmptyPortalPaneItem() &&
+      this.editorBindingsByEditorProxy.size === 0
+    )
   }
 
   getActivePaneItem () {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -3,6 +3,7 @@ const {Errors, FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const EmptyPortalPaneItem = require('./empty-portal-pane-item')
+const SitePositionsComponent = require('./site-positions-component')
 
 module.exports =
 class GuestPortalBinding {
@@ -20,12 +21,22 @@ class GuestPortalBinding {
     this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
     this.openEditorProxies = new Set()
+    this.positionsBySiteId = {}
   }
 
   async initialize () {
     try {
       this.portal = await this.client.joinPortal(this.portalId)
       if (!this.portal) return false
+
+      this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
+      this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
+      this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
+
+      const workspaceElement = this.workspace.getElement()
+      workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
+      workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
+      workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
 
       await this.portal.setDelegate(this)
       if (this.openEditorProxies.size === 0) {
@@ -79,7 +90,39 @@ class GuestPortalBinding {
     return this.lastEditorProxyChangePromise
   }
 
-  updateActivePositions () {}
+  updateActivePositions (positionsBySiteId) {
+    const aboveViewportSiteIds = []
+    const insideViewportSiteIds = []
+    const outsideViewportSiteIds = []
+
+    for (const siteId in positionsBySiteId) {
+      const {editorProxy, position} = positionsBySiteId[siteId]
+      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      if (!editorBinding || editorBinding.editor !== this.getActivePaneItem()) {
+        outsideViewportSiteIds.push(siteId)
+      } else {
+        switch (editorBinding.getDirectionFromViewportToPosition(position)) {
+          case 'upward':
+            aboveViewportSiteIds.push(siteId)
+            break
+          case 'inside':
+            insideViewportSiteIds.push(siteId)
+            break
+          case 'downward':
+          case 'leftward':
+          case 'rightward':
+            outsideViewportSiteIds.push(siteId)
+            break
+        }
+      }
+    }
+
+    const followedSiteId = null // FIXME
+    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
+    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
+    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})
+    this.positionsBySiteId = positionsBySiteId
+  }
 
   updateTether (followState, editorProxy, position) {
     if (!editorProxy) return
@@ -122,6 +165,8 @@ class GuestPortalBinding {
         editor,
         portal: this.portal,
         isHost: false,
+        didScroll: () => this.updateActivePositions(this.positionsBySiteId),
+        didResize: () => this.updateActivePositions(this.positionsBySiteId),
         didDispose: () => {
           this.editorBindingsByEditorProxy.delete(editorProxy)
           this.editorProxiesByEditor.delete(editor)
@@ -219,6 +264,16 @@ class GuestPortalBinding {
   didChangeActivePaneItem (paneItem) {
     if (paneItem !== this.getEmptyPortalPaneItem()) {
       const editorProxy = this.editorProxiesByEditor.get(paneItem)
+      if (editorProxy) {
+        this.workspace.element.appendChild(this.aboveViewportSitePositionsComponent.element)
+        this.workspace.element.appendChild(this.insideViewportSitePositionsComponent.element)
+        this.workspace.element.appendChild(this.outsideViewportSitePositionsComponent.element)
+      } else {
+        this.aboveViewportSitePositionsComponent.element.remove()
+        this.insideViewportSitePositionsComponent.element.remove()
+        this.outsideViewportSitePositionsComponent.element.remove()
+      }
+
       this.portal.activateEditorProxy(editorProxy)
     }
   }
@@ -238,5 +293,20 @@ class GuestPortalBinding {
 
   onDidChange (callback) {
     return this.emitter.on('did-change', callback)
+  }
+
+  buildSitePositionsComponent (position) {
+    return new SitePositionsComponent({
+      position,
+      displayedParticipantsCount: 3,
+      portal: this.portal,
+      onSelectSiteId: (siteId) => {
+        if (siteId === this.portal.getFollowedSiteId()) {
+          this.portal.unfollow()
+        } else {
+          this.portal.follow(siteId)
+        }
+      }
+    })
   }
 }

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -71,14 +71,19 @@ class GuestPortalBinding {
   removeEditorProxy (editorProxy) {
     this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      editorBinding.dispose()
+      if (editorBinding) {
+        editorBinding.dispose()
+        if (this.editorBindingsByEditorProxy.size === 0) {
+          this.portal.follow(1)
+        }
 
-      await this.toggleEmptyPortalPaneItem()
+        await this.toggleEmptyPortalPaneItem()
 
-      const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
-      this.shouldRelayActiveEditorChanges = !isRetracted
-      editorBinding.editor.destroy()
-      this.shouldRelayActiveEditorChanges = true
+        const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
+        this.shouldRelayActiveEditorChanges = !isRetracted
+        editorBinding.editor.destroy()
+        this.shouldRelayActiveEditorChanges = true
+      }
     })
 
     return this.lastEditorProxyChangePromise
@@ -137,8 +142,8 @@ class GuestPortalBinding {
       this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
       this.editorProxiesByEditor.set(editor, editorProxy)
       editorBinding.onDidDispose(() => {
-        this.editorBindingsByEditorProxy.delete(editorProxy)
         this.editorProxiesByEditor.delete(editor)
+        this.editorBindingsByEditorProxy.delete(editorProxy)
       })
 
       this.sitePositionsController.addEditorBinding(editorBinding)
@@ -243,7 +248,9 @@ class GuestPortalBinding {
       this.sitePositionsController.hide()
     }
 
-    if (this.shouldRelayActiveEditorChanges) this.portal.activateEditorProxy(editorProxy)
+    if (this.shouldRelayActiveEditorChanges && paneItem !== this.getEmptyPortalPaneItem()) {
+      this.portal.activateEditorProxy(editorProxy)
+    }
   }
 
   hasPaneItem (paneItem) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -235,16 +235,15 @@ class GuestPortalBinding {
   }
 
   didChangeActivePaneItem (paneItem) {
-    if (paneItem !== this.getEmptyPortalPaneItem()) {
-      const editorProxy = this.editorProxiesByEditor.get(paneItem)
-      if (editorProxy) {
-        this.sitePositionsController.show()
-      } else {
-        this.sitePositionsController.hide()
-      }
+    const editorProxy = this.editorProxiesByEditor.get(paneItem)
 
-      if (this.shouldRelayActiveEditorChanges) this.portal.activateEditorProxy(editorProxy)
+    if (editorProxy || paneItem === this.getEmptyPortalPaneItem()) {
+      this.sitePositionsController.show()
+    } else {
+      this.sitePositionsController.hide()
     }
+
+    if (this.shouldRelayActiveEditorChanges) this.portal.activateEditorProxy(editorProxy)
   }
 
   hasPaneItem (paneItem) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -33,6 +33,7 @@ class GuestPortalBinding {
       this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
       this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
 
+      // TODO Extract method
       const workspaceElement = this.workspace.getElement()
       workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
       workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
@@ -269,10 +270,12 @@ class GuestPortalBinding {
     if (paneItem !== this.getEmptyPortalPaneItem()) {
       const editorProxy = this.editorProxiesByEditor.get(paneItem)
       if (editorProxy) {
+        // TODO Extract method
         this.workspace.element.appendChild(this.aboveViewportSitePositionsComponent.element)
         this.workspace.element.appendChild(this.insideViewportSitePositionsComponent.element)
         this.workspace.element.appendChild(this.outsideViewportSitePositionsComponent.element)
       } else {
+        // TODO Extract method
         this.aboveViewportSitePositionsComponent.element.remove()
         this.insideViewportSitePositionsComponent.element.remove()
         this.outsideViewportSitePositionsComponent.element.remove()

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -138,6 +138,8 @@ class GuestPortalBinding {
         this.editorBindingsByEditorProxy.delete(editorProxy)
         this.editorProxiesByEditor.delete(editor)
       })
+
+      this.sitePositionsController.addEditorBinding(editorBinding)
     }
     return editor
   }

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -20,6 +20,7 @@ class GuestPortalBinding {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
+    this.shouldRelayActiveEditorChanges = true
   }
 
   async initialize () {
@@ -74,7 +75,10 @@ class GuestPortalBinding {
 
       await this.toggleEmptyPortalPaneItem()
 
+      const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
+      this.shouldRelayActiveEditorChanges = !isRetracted
       editorBinding.editor.destroy()
+      this.shouldRelayActiveEditorChanges = true
     })
 
     return this.lastEditorProxyChangePromise
@@ -98,7 +102,9 @@ class GuestPortalBinding {
   async _updateTether (followState, editorProxy, position) {
     if (followState === FollowState.RETRACTED) {
       const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
+      this.shouldRelayActiveEditorChanges = false
       await this.openPaneItem(editor)
+      this.shouldRelayActiveEditorChanges = true
       await this.toggleEmptyPortalPaneItem()
     } else {
       this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
@@ -237,7 +243,7 @@ class GuestPortalBinding {
         this.sitePositionsController.hide()
       }
 
-      this.portal.activateEditorProxy(editorProxy)
+      if (this.shouldRelayActiveEditorChanges) this.portal.activateEditorProxy(editorProxy)
     }
   }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -75,6 +75,27 @@ class GuestPortalBinding {
     return this.lastEditorProxyChangePromise
   }
 
+  updateActivePositions () {}
+
+  updateTether (followState, editorProxy, position) {
+    this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
+      if (editorProxy == null) return
+
+      if (this.openEditorProxies.size === 0) {
+        this.getEmptyPortalPaneItem().destroy()
+      }
+      this.openEditorProxies.add(editorProxy)
+
+      const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
+      await this.openPaneItem(editor)
+
+      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      if (position) editorBinding.updateTether(followState, position)
+    })
+
+    return this.lastEditorProxyChangePromise
+  }
+
   // Private
   findOrCreateEditorForEditorProxy (editorProxy) {
     let editor

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -98,9 +98,7 @@ class GuestPortalBinding {
     for (const siteId in positionsBySiteId) {
       const {editorProxy, position} = positionsBySiteId[siteId]
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      if (!editorBinding || editorBinding.editor !== this.getActivePaneItem()) {
-        outsideViewportSiteIds.push(siteId)
-      } else {
+      if (editorBinding && editorBinding.editor === this.getActivePaneItem()) {
         switch (editorBinding.getDirectionFromViewportToPosition(position)) {
           case 'upward':
             aboveViewportSiteIds.push(siteId)
@@ -114,6 +112,8 @@ class GuestPortalBinding {
             outsideViewportSiteIds.push(siteId)
             break
         }
+      } else {
+        outsideViewportSiteIds.push(siteId)
       }
     }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -1,5 +1,5 @@
-const {Emitter, TextEditor, TextBuffer} = require('atom')
-const {Errors} = require('@atom/teletype-client')
+const {CompositeDisposable, Emitter, TextEditor, TextBuffer} = require('atom')
+const {Errors, FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const EmptyPortalPaneItem = require('./empty-portal-pane-item')
@@ -15,7 +15,9 @@ class GuestPortalBinding {
     this.activePaneItem = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
+    this.editorProxiesByEditor = new WeakMap()
     this.emitter = new Emitter()
+    this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
     this.openEditorProxies = new Set()
   }
@@ -30,6 +32,7 @@ class GuestPortalBinding {
         await this.openPaneItem(this.getEmptyPortalPaneItem())
       }
 
+      this.subscriptions.add(this.workspace.onDidChangeActivePaneItem(this.didChangeActivePaneItem.bind(this)))
       return true
     } catch (error) {
       this.didFailToJoin(error)
@@ -38,6 +41,7 @@ class GuestPortalBinding {
   }
 
   dispose () {
+    this.subscriptions.dispose()
     this.openEditorProxies.clear()
     if (this.emptyPortalItem) this.emptyPortalItem.destroy()
     this.emitDidDispose()
@@ -63,13 +67,13 @@ class GuestPortalBinding {
 
   removeEditorProxy (editorProxy) {
     this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
-      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      editorBinding.editor.destroy()
-
       this.openEditorProxies.delete(editorProxy)
       if (this.openEditorProxies.size === 0) {
         await this.openPaneItem(this.getEmptyPortalPaneItem())
       }
+
+      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      editorBinding.editor.destroy()
     })
 
     return this.lastEditorProxyChangePromise
@@ -78,19 +82,23 @@ class GuestPortalBinding {
   updateActivePositions () {}
 
   updateTether (followState, editorProxy, position) {
+    if (!editorProxy) return
+
     this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
-      if (editorProxy == null) return
+      if (followState === FollowState.RETRACTED) {
+        const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
+        await this.openPaneItem(editor)
 
-      if (this.openEditorProxies.size === 0) {
-        this.getEmptyPortalPaneItem().destroy()
+        this.openEditorProxies.add(editorProxy)
+        if (this.openEditorProxies.size > 0) {
+          this.getEmptyPortalPaneItem().destroy()
+        }
       }
-      this.openEditorProxies.add(editorProxy)
-
-      const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
-      await this.openPaneItem(editor)
 
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      if (position) editorBinding.updateTether(followState, position)
+      if (editorBinding && position) {
+        editorBinding.updateTether(followState, position)
+      }
     })
 
     return this.lastEditorProxyChangePromise
@@ -110,11 +118,15 @@ class GuestPortalBinding {
         editor,
         portal: this.portal,
         isHost: false,
-        didDispose: () => this.editorBindingsByEditorProxy.delete(editorProxy)
+        didDispose: () => {
+          this.editorBindingsByEditorProxy.delete(editorProxy)
+          this.editorProxiesByEditor.delete(editor)
+        }
       })
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
       this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
+      this.editorProxiesByEditor.set(editor, editorProxy)
     }
     return editor
   }
@@ -197,6 +209,13 @@ class GuestPortalBinding {
       await this.workspace.open(newActivePaneItem)
       this.activePaneItem = this.newActivePaneItem
       this.newActivePaneItem = null
+    }
+  }
+
+  didChangeActivePaneItem (paneItem) {
+    if (paneItem !== this.getEmptyPortalPaneItem()) {
+      const editorProxy = this.editorProxiesByEditor.get(paneItem)
+      this.portal.activateEditorProxy(editorProxy)
     }
   }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -102,7 +102,7 @@ class GuestPortalBinding {
     for (const siteId in positionsBySiteId) {
       const {editorProxy, position} = positionsBySiteId[siteId]
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      if (editorBinding && editorBinding.editor === this.getActivePaneItem()) {
+      if (position && editorBinding && editorBinding.editor === this.getActivePaneItem()) {
         switch (editorBinding.getDirectionFromViewportToPosition(position)) {
           case 'upward':
             aboveViewportSiteIds.push(siteId)

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -3,7 +3,7 @@ const {Errors, FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const EmptyPortalPaneItem = require('./empty-portal-pane-item')
-const SitePositionsComponent = require('./site-positions-component')
+const SitePositionsController = require('./site-positions-controller')
 
 module.exports =
 class GuestPortalBinding {
@@ -20,7 +20,6 @@ class GuestPortalBinding {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
-    this.positionsBySiteId = {}
   }
 
   async initialize () {
@@ -28,10 +27,12 @@ class GuestPortalBinding {
       this.portal = await this.client.joinPortal(this.portalId)
       if (!this.portal) return false
 
-      this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
-      this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
-      this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
-      this.showSitePositions()
+      this.sitePositionsController = new SitePositionsController({
+        portal: this.portal,
+        workspace: this.workspace,
+        editorBindingForEditorProxy: (editorProxy) => this.editorBindingsByEditorProxy.get(editorProxy)
+      })
+      this.sitePositionsController.show()
 
       await this.portal.setDelegate(this)
       await this.toggleEmptyPortalPaneItem()
@@ -46,9 +47,7 @@ class GuestPortalBinding {
 
   dispose () {
     this.subscriptions.dispose()
-    this.aboveViewportSitePositionsComponent.destroy()
-    this.insideViewportSitePositionsComponent.destroy()
-    this.outsideViewportSitePositionsComponent.destroy()
+    this.sitePositionsController.destroy()
     if (this.emptyPortalItem) this.emptyPortalItem.destroy()
 
     this.emitDidDispose()
@@ -86,40 +85,7 @@ class GuestPortalBinding {
   }
 
   updateActivePositions (positionsBySiteId) {
-    const aboveViewportSiteIds = []
-    const insideViewportSiteIds = []
-    const outsideViewportSiteIds = []
-
-    for (let siteId in positionsBySiteId) {
-      siteId = parseInt(siteId)
-      if (siteId === this.portal.siteId) continue
-
-      const {editorProxy, position} = positionsBySiteId[siteId]
-      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      if (position && editorBinding && editorBinding.editor === this.getActivePaneItem()) {
-        switch (editorBinding.getDirectionFromViewportToPosition(position)) {
-          case 'upward':
-            aboveViewportSiteIds.push(siteId)
-            break
-          case 'inside':
-            insideViewportSiteIds.push(siteId)
-            break
-          case 'downward':
-          case 'leftward':
-          case 'rightward':
-            outsideViewportSiteIds.push(siteId)
-            break
-        }
-      } else {
-        outsideViewportSiteIds.push(siteId)
-      }
-    }
-
-    const followedSiteId = this.portal.getFollowedSiteId()
-    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
-    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
-    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})
-    this.positionsBySiteId = positionsBySiteId
+    this.sitePositionsController.updateActivePositions(positionsBySiteId)
   }
 
   updateTether (followState, editorProxy, position) {
@@ -161,18 +127,17 @@ class GuestPortalBinding {
       editorBinding = new EditorBinding({
         editor,
         portal: this.portal,
-        isHost: false,
-        didScroll: () => this.updateActivePositions(this.positionsBySiteId),
-        didResize: () => this.updateActivePositions(this.positionsBySiteId),
-        didDispose: () => {
-          this.editorBindingsByEditorProxy.delete(editorProxy)
-          this.editorProxiesByEditor.delete(editor)
-        }
+        isHost: false
       })
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
+
       this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
       this.editorProxiesByEditor.set(editor, editorProxy)
+      editorBinding.onDidDispose(() => {
+        this.editorBindingsByEditorProxy.delete(editorProxy)
+        this.editorProxiesByEditor.delete(editor)
+      })
     }
     return editor
   }
@@ -269,9 +234,9 @@ class GuestPortalBinding {
     if (paneItem !== this.getEmptyPortalPaneItem()) {
       const editorProxy = this.editorProxiesByEditor.get(paneItem)
       if (editorProxy) {
-        this.showSitePositions()
+        this.sitePositionsController.show()
       } else {
-        this.hideSitePositions()
+        this.sitePositionsController.hide()
       }
 
       this.portal.activateEditorProxy(editorProxy)
@@ -300,36 +265,5 @@ class GuestPortalBinding {
 
   onDidChange (callback) {
     return this.emitter.on('did-change', callback)
-  }
-
-  // Private
-  showSitePositions () {
-    const workspaceElement = this.workspace.getElement()
-    workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
-    workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
-    workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
-  }
-
-  // Private
-  hideSitePositions () {
-    this.aboveViewportSitePositionsComponent.element.remove()
-    this.insideViewportSitePositionsComponent.element.remove()
-    this.outsideViewportSitePositionsComponent.element.remove()
-  }
-
-  // Private
-  buildSitePositionsComponent (position) {
-    return new SitePositionsComponent({
-      position,
-      displayedParticipantsCount: 3,
-      portal: this.portal,
-      onSelectSiteId: (siteId) => {
-        if (siteId === this.portal.getFollowedSiteId()) {
-          this.portal.unfollow()
-        } else {
-          this.portal.follow(siteId)
-        }
-      }
-    })
   }
 }

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -161,6 +161,7 @@ class GuestPortalBinding {
       buffer = new TextBuffer()
       bufferBinding = new BufferBinding({
         buffer,
+        isHost: false,
         didDispose: () => this.bufferBindingsByBufferProxy.delete(bufferProxy)
       })
       bufferBinding.setBufferProxy(bufferProxy)

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -223,7 +223,7 @@ class GuestPortalBinding {
 
   async openPaneItem (newActivePaneItem) {
     this.newActivePaneItem = newActivePaneItem
-    await this.workspace.open(newActivePaneItem)
+    await this.workspace.open(newActivePaneItem, {searchAllPanes: true})
     this.lastActivePaneItem = this.newActivePaneItem
     this.newActivePaneItem = null
   }

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -20,7 +20,6 @@ class GuestPortalBinding {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
-    this.openEditorProxies = new Set()
     this.positionsBySiteId = {}
   }
 
@@ -35,9 +34,7 @@ class GuestPortalBinding {
       this.showSitePositions()
 
       await this.portal.setDelegate(this)
-      if (this.openEditorProxies.size === 0) {
-        await this.openPaneItem(this.getEmptyPortalPaneItem())
-      }
+      await this.toggleEmptyPortalPaneItem()
 
       this.subscriptions.add(this.workspace.onDidChangeActivePaneItem(this.didChangeActivePaneItem.bind(this)))
       return true
@@ -49,7 +46,6 @@ class GuestPortalBinding {
 
   dispose () {
     this.subscriptions.dispose()
-    this.openEditorProxies.clear()
     this.aboveViewportSitePositionsComponent.destroy()
     this.insideViewportSitePositionsComponent.destroy()
     this.outsideViewportSitePositionsComponent.destroy()
@@ -78,12 +74,11 @@ class GuestPortalBinding {
 
   removeEditorProxy (editorProxy) {
     this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
-      this.openEditorProxies.delete(editorProxy)
-      if (this.openEditorProxies.size === 0) {
-        await this.openPaneItem(this.getEmptyPortalPaneItem())
-      }
-
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      editorBinding.dispose()
+
+      await this.toggleEmptyPortalPaneItem()
+
       editorBinding.editor.destroy()
     })
 
@@ -142,11 +137,7 @@ class GuestPortalBinding {
     if (followState === FollowState.RETRACTED) {
       const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
       await this.openPaneItem(editor)
-
-      this.openEditorProxies.add(editorProxy)
-      if (this.openEditorProxies.size > 0) {
-        this.getEmptyPortalPaneItem().destroy()
-      }
+      await this.toggleEmptyPortalPaneItem()
     } else {
       this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
     }
@@ -203,6 +194,17 @@ class GuestPortalBinding {
       this.bufferBindingsByBufferProxy.set(bufferProxy, bufferBinding)
     }
     return buffer
+  }
+
+  // Private
+  async toggleEmptyPortalPaneItem () {
+    const emptyPortalItem = this.getEmptyPortalPaneItem()
+    const pane = this.workspace.paneForItem(emptyPortalItem)
+    if (this.editorBindingsByEditorProxy.size === 0) {
+      if (!pane) await this.openPaneItem(emptyPortalItem)
+    } else {
+      if (pane) emptyPortalItem.destroy()
+    }
   }
 
   activate () {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -192,10 +192,12 @@ class GuestPortalBinding {
   }
 
   async openPaneItem (newActivePaneItem) {
-    this.newActivePaneItem = newActivePaneItem
-    await this.workspace.open(newActivePaneItem)
-    this.activePaneItem = this.newActivePaneItem
-    this.newActivePaneItem = null
+    if (newActivePaneItem !== this.getActivePaneItem()) {
+      this.newActivePaneItem = newActivePaneItem
+      await this.workspace.open(newActivePaneItem)
+      this.activePaneItem = this.newActivePaneItem
+      this.newActivePaneItem = null
+    }
   }
 
   getActivePaneItem () {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -54,7 +54,11 @@ class GuestPortalBinding {
   dispose () {
     this.subscriptions.dispose()
     this.openEditorProxies.clear()
+    this.aboveViewportSitePositionsComponent.destroy()
+    this.insideViewportSitePositionsComponent.destroy()
+    this.outsideViewportSitePositionsComponent.destroy()
     if (this.emptyPortalItem) this.emptyPortalItem.destroy()
+
     this.emitDidDispose()
   }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -93,6 +93,10 @@ class GuestPortalBinding {
         if (this.openEditorProxies.size > 0) {
           this.getEmptyPortalPaneItem().destroy()
         }
+      } else {
+        this.editorBindingsByEditorProxy.forEach((editorBinding) => {
+          editorBinding.updateTether(followState)
+        })
       }
 
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -32,12 +32,7 @@ class GuestPortalBinding {
       this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
       this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
       this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
-
-      // TODO Extract method
-      const workspaceElement = this.workspace.getElement()
-      workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
-      workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
-      workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
+      this.showSitePositions()
 
       await this.portal.setDelegate(this)
       if (this.openEditorProxies.size === 0) {
@@ -270,15 +265,9 @@ class GuestPortalBinding {
     if (paneItem !== this.getEmptyPortalPaneItem()) {
       const editorProxy = this.editorProxiesByEditor.get(paneItem)
       if (editorProxy) {
-        // TODO Extract method
-        this.workspace.element.appendChild(this.aboveViewportSitePositionsComponent.element)
-        this.workspace.element.appendChild(this.insideViewportSitePositionsComponent.element)
-        this.workspace.element.appendChild(this.outsideViewportSitePositionsComponent.element)
+        this.showSitePositions()
       } else {
-        // TODO Extract method
-        this.aboveViewportSitePositionsComponent.element.remove()
-        this.insideViewportSitePositionsComponent.element.remove()
-        this.outsideViewportSitePositionsComponent.element.remove()
+        this.hideSitePositions()
       }
 
       this.portal.activateEditorProxy(editorProxy)
@@ -300,6 +289,19 @@ class GuestPortalBinding {
 
   onDidChange (callback) {
     return this.emitter.on('did-change', callback)
+  }
+
+  showSitePositions () {
+    const workspaceElement = this.workspace.getElement()
+    workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
+    workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
+    workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
+  }
+
+  hideSitePositions () {
+    this.aboveViewportSitePositionsComponent.element.remove()
+    this.insideViewportSitePositionsComponent.element.remove()
+    this.outsideViewportSitePositionsComponent.element.remove()
   }
 
   buildSitePositionsComponent (position) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -256,12 +256,10 @@ class GuestPortalBinding {
   }
 
   async openPaneItem (newActivePaneItem) {
-    if (newActivePaneItem !== this.getActivePaneItem()) {
-      this.newActivePaneItem = newActivePaneItem
-      await this.workspace.open(newActivePaneItem)
-      this.activePaneItem = this.newActivePaneItem
-      this.newActivePaneItem = null
-    }
+    this.newActivePaneItem = newActivePaneItem
+    await this.workspace.open(newActivePaneItem)
+    this.activePaneItem = this.newActivePaneItem
+    this.newActivePaneItem = null
   }
 
   didChangeActivePaneItem (paneItem) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -291,6 +291,7 @@ class GuestPortalBinding {
     return this.emitter.on('did-change', callback)
   }
 
+  // Private
   showSitePositions () {
     const workspaceElement = this.workspace.getElement()
     workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
@@ -298,12 +299,14 @@ class GuestPortalBinding {
     workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
   }
 
+  // Private
   hideSitePositions () {
     this.aboveViewportSitePositionsComponent.element.remove()
     this.insideViewportSitePositionsComponent.element.remove()
     this.outsideViewportSitePositionsComponent.element.remove()
   }
 
+  // Private
   buildSitePositionsComponent (position) {
     return new SitePositionsComponent({
       position,

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -128,30 +128,33 @@ class GuestPortalBinding {
   }
 
   updateTether (followState, editorProxy, position) {
-    if (!editorProxy) return
-
-    this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
-      if (followState === FollowState.RETRACTED) {
-        const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
-        await this.openPaneItem(editor)
-
-        this.openEditorProxies.add(editorProxy)
-        if (this.openEditorProxies.size > 0) {
-          this.getEmptyPortalPaneItem().destroy()
-        }
-      } else {
-        this.editorBindingsByEditorProxy.forEach((editorBinding) => {
-          editorBinding.updateTether(followState)
-        })
-      }
-
-      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
-      if (editorBinding && position) {
-        editorBinding.updateTether(followState, position)
-      }
-    })
+    if (editorProxy) {
+      this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(() =>
+        this._updateTether(followState, editorProxy, position)
+      )
+    }
 
     return this.lastEditorProxyChangePromise
+  }
+
+  // Private
+  async _updateTether (followState, editorProxy, position) {
+    if (followState === FollowState.RETRACTED) {
+      const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
+      await this.openPaneItem(editor)
+
+      this.openEditorProxies.add(editorProxy)
+      if (this.openEditorProxies.size > 0) {
+        this.getEmptyPortalPaneItem().destroy()
+      }
+    } else {
+      this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
+    }
+
+    const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+    if (editorBinding && position) {
+      editorBinding.updateTether(followState, position)
+    }
   }
 
   // Private

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -35,6 +35,7 @@ class GuestPortalBinding {
       await this.toggleEmptyPortalPaneItem()
 
       this.subscriptions.add(this.workspace.onDidChangeActivePaneItem(this.didChangeActivePaneItem.bind(this)))
+      this.subscriptions.add(this.workspace.onDidDestroyPaneItem(this.didDestroyPaneItem.bind(this)))
       return true
     } catch (error) {
       this.didFailToJoin(error)
@@ -81,7 +82,9 @@ class GuestPortalBinding {
 
         const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
         this.shouldRelayActiveEditorChanges = !isRetracted
+        this.lastDestroyedEditorWasRemovedByHost = true
         editorBinding.editor.destroy()
+        this.lastDestroyedEditorWasRemovedByHost = false
         this.shouldRelayActiveEditorChanges = true
       }
     })
@@ -251,6 +254,17 @@ class GuestPortalBinding {
 
     if (this.shouldRelayActiveEditorChanges && paneItem !== this.getEmptyPortalPaneItem()) {
       this.portal.activateEditorProxy(editorProxy)
+    }
+  }
+
+  didDestroyPaneItem () {
+    const emptyPortalItem = this.getEmptyPortalPaneItem()
+    const hasNoPortalPaneItem = this.workspace.getPaneItems().every((item) => (
+      item !== emptyPortalItem && !this.editorProxiesByEditor.has(item)
+    ))
+    const lastDestroyedEditorWasClosedManually = !this.lastDestroyedEditorWasRemovedByHost
+    if (hasNoPortalPaneItem && lastDestroyedEditorWasClosedManually) {
+      this.leave()
     }
   }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -62,7 +62,7 @@ class GuestPortalBinding {
   }
 
   addEditorProxy (editorProxy) {
-
+    // TODO Implement in order to allow guests to open any editor that's in the host's workspace
   }
 
   removeEditorProxy (editorProxy) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -13,7 +13,7 @@ class GuestPortalBinding {
     this.workspace = workspace
     this.notificationManager = notificationManager
     this.emitDidDispose = didDispose
-    this.activePaneItem = null
+    this.lastActivePaneItem = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
     this.editorProxiesByEditor = new WeakMap()
@@ -203,10 +203,10 @@ class GuestPortalBinding {
   }
 
   activate () {
-    const activePaneItem = this.getActivePaneItem()
-    const pane = this.workspace.paneForItem(activePaneItem)
-    if (pane && activePaneItem) {
-      pane.activateItem(activePaneItem)
+    const paneItem = this.lastActivePaneItem
+    const pane = this.workspace.paneForItem(paneItem)
+    if (pane && paneItem) {
+      pane.activateItem(paneItem)
       pane.activate()
     }
   }
@@ -233,7 +233,6 @@ class GuestPortalBinding {
       description: 'Your host stopped sharing their editor.',
       dismissable: true
     })
-    this.activePaneItem = null
   }
 
   hostDidLoseConnection () {
@@ -244,7 +243,6 @@ class GuestPortalBinding {
       ),
       dismissable: true
     })
-    this.activePaneItem = null
   }
 
   leave () {
@@ -258,7 +256,7 @@ class GuestPortalBinding {
   async openPaneItem (newActivePaneItem) {
     this.newActivePaneItem = newActivePaneItem
     await this.workspace.open(newActivePaneItem)
-    this.activePaneItem = this.newActivePaneItem
+    this.lastActivePaneItem = this.newActivePaneItem
     this.newActivePaneItem = null
   }
 
@@ -275,8 +273,15 @@ class GuestPortalBinding {
     }
   }
 
+  hasPaneItem (paneItem) {
+    return (
+      paneItem === this.getEmptyPortalPaneItem() ||
+      this.editorProxiesByEditor.has(paneItem)
+    )
+  }
+
   getActivePaneItem () {
-    return this.newActivePaneItem ? this.newActivePaneItem : this.activePaneItem
+    return this.newActivePaneItem || this.workspace.getActivePaneItem()
   }
 
   getEmptyPortalPaneItem () {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -57,18 +57,8 @@ class GuestPortalBinding {
     this.emitter.emit('did-change')
   }
 
-  activateEditorProxy (editorProxy) {
-    this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
-      if (this.openEditorProxies.size === 0) {
-        this.getEmptyPortalPaneItem().destroy()
-      }
-      this.openEditorProxies.add(editorProxy)
+  addEditorProxy (editorProxy) {
 
-      const editor = this.findOrCreateEditorForEditorProxy(editorProxy)
-      await this.openPaneItem(editor)
-    })
-
-    return this.lastEditorProxyChangePromise
   }
 
   removeEditorProxy (editorProxy) {

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -27,11 +27,7 @@ class GuestPortalBinding {
       this.portal = await this.client.joinPortal(this.portalId)
       if (!this.portal) return false
 
-      this.sitePositionsController = new SitePositionsController({
-        portal: this.portal,
-        workspace: this.workspace,
-        editorBindingForEditorProxy: (editorProxy) => this.editorBindingsByEditorProxy.get(editorProxy)
-      })
+      this.sitePositionsController = new SitePositionsController({portal: this.portal, workspace: this.workspace})
       this.sitePositionsController.show()
 
       await this.portal.setDelegate(this)

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -95,7 +95,10 @@ class GuestPortalBinding {
     const insideViewportSiteIds = []
     const outsideViewportSiteIds = []
 
-    for (const siteId in positionsBySiteId) {
+    for (let siteId in positionsBySiteId) {
+      siteId = parseInt(siteId)
+      if (siteId === this.portal.siteId) continue
+
       const {editorProxy, position} = positionsBySiteId[siteId]
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
       if (position && editorBinding && editorBinding.editor === this.getActivePaneItem()) {
@@ -117,7 +120,7 @@ class GuestPortalBinding {
       }
     }
 
-    const followedSiteId = null // FIXME
+    const followedSiteId = this.portal.getFollowedSiteId()
     this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
     this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
     this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -22,9 +22,10 @@ class HostPortalBinding {
       if (!this.portal) return false
 
       this.portal.setDelegate(this)
-      this.disposables.add(this.workspace.observeActiveTextEditor(
-        this.didChangeActiveTextEditor.bind(this)
-      ))
+      this.disposables.add(
+        this.workspace.observeActiveTextEditor(this.didChangeActiveTextEditor.bind(this)),
+        this.workspace.onDidDestroyPaneItem(this.didDestroyPaneItem.bind(this))
+      )
 
       this.workspace.getElement().classList.add('teletype-Host')
       return true
@@ -64,10 +65,7 @@ class HostPortalBinding {
   }
 
   didChangeActiveTextEditor (editor) {
-    if (editor == null || editor.isRemote) {
-      this.portal.setActiveEditorProxy(null)
-      return
-    }
+    if (editor == null || editor.isRemote) return
 
     let editorBinding = this.editorBindingsByEditor.get(editor)
     if (!editorBinding) {
@@ -98,7 +96,14 @@ class HostPortalBinding {
       this.editorBindingsByEditor.set(editor, editorBinding)
     }
 
-    this.portal.setActiveEditorProxy(editorBinding.editorProxy)
+    this.portal.activateEditorProxy(editorBinding.editorProxy)
+  }
+
+  didDestroyPaneItem ({item}) {
+    const editorBinding = this.editorBindingsByEditor.get(item)
+    if (editorBinding) {
+      this.portal.removeEditorProxy(editorBinding.editorProxy)
+    }
   }
 
   getBufferProxyURI (buffer) {

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -86,10 +86,7 @@ class HostPortalBinding {
       }
 
       editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
-      const editorProxy = this.portal.createEditorProxy({
-        bufferProxy,
-        selections: editor.selectionsMarkerLayer.bufferMarkerLayer.createSnapshot()
-      })
+      const editorProxy = this.portal.createEditorProxy({bufferProxy})
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
 

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -26,7 +26,6 @@ class HostPortalBinding {
       if (!this.portal) return false
 
       this.sitePositionsController = new SitePositionsController({portal: this.portal, workspace: this.workspace})
-      this.sitePositionsController.show()
 
       this.portal.setDelegate(this)
       this.disposables.add(
@@ -75,8 +74,10 @@ class HostPortalBinding {
     if (editor && !editor.isRemote) {
       const editorProxy = this.findOrCreateEditorProxyForEditor(editor)
       this.portal.activateEditorProxy(editorProxy)
+      this.sitePositionsController.show()
     } else {
       this.portal.activateEditorProxy(null)
+      this.sitePositionsController.hide()
     }
   }
 

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const {CompositeDisposable, Emitter} = require('atom')
+const {FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 
@@ -10,9 +11,11 @@ class HostPortalBinding {
     this.workspace = workspace
     this.notificationManager = notificationManager
     this.editorBindingsByEditor = new WeakMap()
+    this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBuffer = new WeakMap()
     this.disposables = new CompositeDisposable()
     this.emitter = new Emitter()
+    this.lastUpdateTetherPromise = Promise.resolve()
     this.didDispose = didDispose
   }
 
@@ -75,7 +78,26 @@ class HostPortalBinding {
 
   updateActivePositions () {}
 
-  updateTether () {}
+  updateTether (followState, editorProxy, position) {
+    if (editorProxy) {
+      this.lastUpdateTetherPromise = this.lastUpdateTetherPromise.then(() =>
+        this._updateTether(followState, editorProxy, position)
+      )
+    }
+  }
+
+  // Private
+  async _updateTether (followState, editorProxy, position) {
+    const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+
+    if (followState === FollowState.RETRACTED) {
+      await this.workspace.open(editorBinding.editor)
+    } else {
+      this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
+    }
+
+    if (position) editorBinding.updateTether(followState, position)
+  }
 
   didDestroyPaneItem ({item}) {
     const editorBinding = this.editorBindingsByEditor.get(item)
@@ -92,10 +114,17 @@ class HostPortalBinding {
       editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
       const bufferProxy = this.findOrCreateBufferProxyForBuffer(editor.getBuffer())
       const editorProxy = this.portal.createEditorProxy({bufferProxy})
+      editorBinding = new EditorBinding({
+        editor,
+        portal: this.portal,
+        isHost: true,
+        didDispose: () => this.editorBindingsByEditorProxy.delete(editorProxy)
+      })
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
 
       this.editorBindingsByEditor.set(editor, editorBinding)
+      this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
 
       return editorProxy
     }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -106,7 +106,6 @@ class HostPortalBinding {
     } else {
       this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
     }
-
   }
 
   didDestroyPaneItem ({item}) {

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -46,6 +46,7 @@ class HostPortalBinding {
 
   dispose () {
     this.workspace.getElement().classList.remove('teletype-Host')
+    this.sitePositionsController.destroy()
     this.disposables.dispose()
     this.didDispose()
   }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -99,7 +99,7 @@ class HostPortalBinding {
     const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
 
     if (followState === FollowState.RETRACTED) {
-      await this.workspace.open(editorBinding.editor)
+      await this.workspace.open(editorBinding.editor, {searchAllPanes: true})
     } else {
       this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
     }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -111,20 +111,17 @@ class HostPortalBinding {
     if (editorBinding) {
       return editorBinding.editorProxy
     } else {
-      editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
       const bufferProxy = this.findOrCreateBufferProxyForBuffer(editor.getBuffer())
       const editorProxy = this.portal.createEditorProxy({bufferProxy})
-      editorBinding = new EditorBinding({
-        editor,
-        portal: this.portal,
-        isHost: true,
-        didDispose: () => this.editorBindingsByEditorProxy.delete(editorProxy)
-      })
+      editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
 
       this.editorBindingsByEditor.set(editor, editorBinding)
       this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
+      editorBinding.onDidDispose(() => {
+        this.editorBindingsByEditorProxy.delete(editorProxy)
+      })
 
       return editorProxy
     }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -92,6 +92,8 @@ class HostPortalBinding {
         this._updateTether(followState, editorProxy, position)
       )
     }
+
+    return this.lastUpdateTetherPromise
   }
 
   // Private

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -102,11 +102,11 @@ class HostPortalBinding {
 
     if (followState === FollowState.RETRACTED) {
       await this.workspace.open(editorBinding.editor, {searchAllPanes: true})
+      if (position) editorBinding.updateTether(followState, position)
     } else {
       this.editorBindingsByEditorProxy.forEach((b) => b.updateTether(followState))
     }
 
-    if (position) editorBinding.updateTether(followState, position)
   }
 
   didDestroyPaneItem ({item}) {

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -143,7 +143,7 @@ class HostPortalBinding {
     if (bufferBinding) {
       return bufferBinding.bufferProxy
     } else {
-      bufferBinding = new BufferBinding({buffer})
+      bufferBinding = new BufferBinding({buffer, isHost: true})
       const bufferProxy = this.portal.createBufferProxy({
         uri: this.getBufferProxyURI(buffer),
         history: buffer.getHistory()

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -65,35 +65,12 @@ class HostPortalBinding {
   }
 
   didChangeActiveTextEditor (editor) {
-    if (editor == null || editor.isRemote) return
-
-    let editorBinding = this.editorBindingsByEditor.get(editor)
-    if (!editorBinding) {
-      const buffer = editor.getBuffer()
-
-      let bufferBinding = this.bufferBindingsByBuffer.get(buffer)
-      let bufferProxy = bufferBinding ? bufferBinding.bufferProxy : null
-      if (!bufferBinding) {
-        bufferBinding = new BufferBinding({buffer})
-        bufferProxy = this.portal.createBufferProxy({
-          uri: this.getBufferProxyURI(buffer),
-          history: buffer.getHistory()
-        })
-        bufferBinding.setBufferProxy(bufferProxy)
-        bufferProxy.setDelegate(bufferBinding)
-
-        this.bufferBindingsByBuffer.set(buffer, bufferBinding)
-      }
-
-      editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
-      const editorProxy = this.portal.createEditorProxy({bufferProxy})
-      editorBinding.setEditorProxy(editorProxy)
-      editorProxy.setDelegate(editorBinding)
-
-      this.editorBindingsByEditor.set(editor, editorBinding)
+    if (editor && !editor.isRemote) {
+      const editorProxy = this.findOrCreateEditorProxyForEditor(editor)
+      this.portal.activateEditorProxy(editorProxy)
+    } else {
+      this.portal.activateEditorProxy(null)
     }
-
-    this.portal.activateEditorProxy(editorBinding.editorProxy)
   }
 
   updateActivePositions () {}
@@ -104,6 +81,42 @@ class HostPortalBinding {
     const editorBinding = this.editorBindingsByEditor.get(item)
     if (editorBinding) {
       this.portal.removeEditorProxy(editorBinding.editorProxy)
+    }
+  }
+
+  findOrCreateEditorProxyForEditor (editor) {
+    let editorBinding = this.editorBindingsByEditor.get(editor)
+    if (editorBinding) {
+      return editorBinding.editorProxy
+    } else {
+      editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
+      const bufferProxy = this.findOrCreateBufferProxyForBuffer(editor.getBuffer())
+      const editorProxy = this.portal.createEditorProxy({bufferProxy})
+      editorBinding.setEditorProxy(editorProxy)
+      editorProxy.setDelegate(editorBinding)
+
+      this.editorBindingsByEditor.set(editor, editorBinding)
+
+      return editorProxy
+    }
+  }
+
+  findOrCreateBufferProxyForBuffer (buffer) {
+    let bufferBinding = this.bufferBindingsByBuffer.get(buffer)
+    if (bufferBinding) {
+      return bufferBinding.bufferProxy
+    } else {
+      bufferBinding = new BufferBinding({buffer})
+      const bufferProxy = this.portal.createBufferProxy({
+        uri: this.getBufferProxyURI(buffer),
+        history: buffer.getHistory()
+      })
+      bufferBinding.setBufferProxy(bufferProxy)
+      bufferProxy.setDelegate(bufferBinding)
+
+      this.bufferBindingsByBuffer.set(buffer, bufferBinding)
+
+      return bufferProxy
     }
   }
 

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -96,6 +96,10 @@ class HostPortalBinding {
     this.portal.activateEditorProxy(editorBinding.editorProxy)
   }
 
+  updateActivePositions () {}
+
+  updateTether () {}
+
   didDestroyPaneItem ({item}) {
     const editorBinding = this.editorBindingsByEditor.get(item)
     if (editorBinding) {

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -3,6 +3,7 @@ const {CompositeDisposable, Emitter} = require('atom')
 const {FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
+const SitePositionsController = require('./site-positions-controller')
 
 module.exports =
 class HostPortalBinding {
@@ -23,6 +24,9 @@ class HostPortalBinding {
     try {
       this.portal = await this.client.createPortal()
       if (!this.portal) return false
+
+      this.sitePositionsController = new SitePositionsController({portal: this.portal, workspace: this.workspace})
+      this.sitePositionsController.show()
 
       this.portal.setDelegate(this)
       this.disposables.add(
@@ -76,7 +80,9 @@ class HostPortalBinding {
     }
   }
 
-  updateActivePositions () {}
+  updateActivePositions (positionsBySiteId) {
+    this.sitePositionsController.updateActivePositions(positionsBySiteId)
+  }
 
   updateTether (followState, editorProxy, position) {
     if (editorProxy) {
@@ -122,6 +128,8 @@ class HostPortalBinding {
       editorBinding.onDidDispose(() => {
         this.editorBindingsByEditorProxy.delete(editorProxy)
       })
+
+      this.sitePositionsController.addEditorBinding(editorBinding)
 
       return editorProxy
     }

--- a/lib/portal-binding-manager.js
+++ b/lib/portal-binding-manager.js
@@ -110,7 +110,7 @@ class PortalBindingManager {
     const activePaneItem = this.workspace.getActivePaneItem()
     for (const [_, portalBindingPromise] of this.promisesByGuestPortalId) { // eslint-disable-line no-unused-vars
       const portalBinding = await portalBindingPromise
-      if (portalBinding.getActivePaneItem() === activePaneItem) {
+      if (portalBinding.hasPaneItem(activePaneItem)) {
         return portalBinding
       }
     }

--- a/lib/site-positions-component.js
+++ b/lib/site-positions-component.js
@@ -28,6 +28,10 @@ class SitePositionsComponent {
 
   renderSite (siteId) {
     const {portal, followedSiteId} = this.props
+
+    // FIXME Without this statement, tests fail in strange ways 🤔
+    if (!portal.getSiteIdentity(siteId)) return null
+
     const {login} = portal.getSiteIdentity(siteId)
 
     return $.div({className: 'SitePositionsComponent-site'},

--- a/lib/site-positions-component.js
+++ b/lib/site-positions-component.js
@@ -28,10 +28,6 @@ class SitePositionsComponent {
 
   renderSite (siteId) {
     const {portal, followedSiteId} = this.props
-
-    // FIXME Without this statement, tests fail in strange ways 🤔
-    if (!portal.getSiteIdentity(siteId)) return null
-
     const {login} = portal.getSiteIdentity(siteId)
 
     return $.div({className: 'SitePositionsComponent-site'},

--- a/lib/site-positions-controller.js
+++ b/lib/site-positions-controller.js
@@ -1,0 +1,104 @@
+const {CompositeDisposable} = require('atom')
+const SitePositionsComponent = require('./site-positions-component')
+
+module.exports =
+class SitePositionsController {
+  constructor ({portal, workspace}) {
+    this.portal = portal
+    this.workspace = workspace
+    this.subscriptions = new CompositeDisposable()
+    this.editorBindingsByEditorProxy = new WeakMap()
+    this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
+    this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
+    this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
+    this.positionsBySiteId = {}
+  }
+
+  destroy () {
+    this.subscriptions.dispose()
+    this.aboveViewportSitePositionsComponent.destroy()
+    this.insideViewportSitePositionsComponent.destroy()
+    this.outsideViewportSitePositionsComponent.destroy()
+  }
+
+  show () {
+    const workspaceElement = this.workspace.getElement()
+    workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
+    workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
+    workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
+  }
+
+  hide () {
+    this.aboveViewportSitePositionsComponent.element.remove()
+    this.insideViewportSitePositionsComponent.element.remove()
+    this.outsideViewportSitePositionsComponent.element.remove()
+  }
+
+  addEditorBinding (editorBinding) {
+    this.editorBindingsByEditorProxy.set(editorBinding.editorProxy, editorBinding)
+
+    const didResizeSubscription = editorBinding.onDidResize(() => this.updateActivePositions(this.positionsBySiteId))
+    const didScrollSubscription = editorBinding.onDidScroll(() => this.updateActivePositions(this.positionsBySiteId))
+    this.subscriptions.add(didResizeSubscription)
+    this.subscriptions.add(didScrollSubscription)
+
+    editorBinding.onDidDispose(() => {
+      didResizeSubscription.dispose()
+      didScrollSubscription.dispose()
+      this.editorBindingsByEditorProxy.delete(editorBinding.editorProxy)
+    })
+  }
+
+  updateActivePositions (positionsBySiteId) {
+    const aboveViewportSiteIds = []
+    const insideViewportSiteIds = []
+    const outsideViewportSiteIds = []
+
+    for (let siteId in positionsBySiteId) {
+      siteId = parseInt(siteId)
+      if (siteId === this.portal.siteId) continue
+
+      const {editorProxy, position} = positionsBySiteId[siteId]
+      const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
+      if (position && editorBinding && editorBinding.editor === this.workspace.getActivePaneItem()) {
+        switch (editorBinding.getDirectionFromViewportToPosition(position)) {
+          case 'upward':
+            aboveViewportSiteIds.push(siteId)
+            break
+          case 'inside':
+            insideViewportSiteIds.push(siteId)
+            break
+          case 'downward':
+          case 'leftward':
+          case 'rightward':
+            outsideViewportSiteIds.push(siteId)
+            break
+        }
+      } else {
+        outsideViewportSiteIds.push(siteId)
+      }
+    }
+
+    const followedSiteId = this.portal.getFollowedSiteId()
+    this.aboveViewportSitePositionsComponent.update({siteIds: aboveViewportSiteIds, followedSiteId})
+    this.insideViewportSitePositionsComponent.update({siteIds: insideViewportSiteIds, followedSiteId})
+    this.outsideViewportSitePositionsComponent.update({siteIds: outsideViewportSiteIds, followedSiteId})
+    this.positionsBySiteId = positionsBySiteId
+  }
+
+  // Private
+  buildSitePositionsComponent (position) {
+    return new SitePositionsComponent({
+      position,
+      displayedParticipantsCount: 3,
+      portal: this.portal,
+      onSelectSiteId: (siteId) => {
+        if (siteId === this.portal.getFollowedSiteId()) {
+          this.portal.unfollow()
+        } else {
+          this.portal.follow(siteId)
+        }
+      }
+    })
+  }
+}

--- a/lib/site-positions-controller.js
+++ b/lib/site-positions-controller.js
@@ -23,10 +23,10 @@ class SitePositionsController {
   }
 
   show () {
-    const workspaceElement = this.workspace.getElement()
-    workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
-    workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
-    workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
+    const containerElement = this.workspace.getCenter().paneContainer.getElement()
+    containerElement.appendChild(this.aboveViewportSitePositionsComponent.element)
+    containerElement.appendChild(this.insideViewportSitePositionsComponent.element)
+    containerElement.appendChild(this.outsideViewportSitePositionsComponent.element)
     this.visible = true
   }
 

--- a/lib/site-positions-controller.js
+++ b/lib/site-positions-controller.js
@@ -8,6 +8,7 @@ class SitePositionsController {
     this.workspace = workspace
     this.subscriptions = new CompositeDisposable()
     this.editorBindingsByEditorProxy = new WeakMap()
+    this.visible = false
     this.aboveViewportSitePositionsComponent = this.buildSitePositionsComponent('upper-right')
     this.insideViewportSitePositionsComponent = this.buildSitePositionsComponent('middle-right')
     this.outsideViewportSitePositionsComponent = this.buildSitePositionsComponent('lower-right')
@@ -26,12 +27,14 @@ class SitePositionsController {
     workspaceElement.appendChild(this.aboveViewportSitePositionsComponent.element)
     workspaceElement.appendChild(this.insideViewportSitePositionsComponent.element)
     workspaceElement.appendChild(this.outsideViewportSitePositionsComponent.element)
+    this.visible = true
   }
 
   hide () {
     this.aboveViewportSitePositionsComponent.element.remove()
     this.insideViewportSitePositionsComponent.element.remove()
     this.outsideViewportSitePositionsComponent.element.remove()
+    this.visible = false
   }
 
   addEditorBinding (editorBinding) {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -50,6 +50,9 @@ class TeletypePackage {
     this.subscriptions.add(this.commandRegistry.add('atom-workspace', {
       'teletype:join-portal': () => this.joinPortal()
     }))
+    this.subscriptions.add(this.commandRegistry.add('teletype-RemotePaneItem', {
+      'teletype:leave-portal': () => this.leavePortal()
+    }))
     this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
       'teletype:close-portal': () => this.closeHostPortal()
     }))
@@ -99,6 +102,14 @@ class TeletypePackage {
     const manager = await this.getPortalBindingManager()
     const hostPortalBinding = await manager.getHostPortalBinding()
     hostPortalBinding.close()
+  }
+
+  async leavePortal () {
+    this.showPopover()
+
+    const manager = await this.getPortalBindingManager()
+    const guestPortalBinding = await manager.getActiveGuestPortalBinding()
+    guestPortalBinding.leave()
   }
 
   async consumeStatusBar (statusBar) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "https://github.com/atom/teletype-client#e5dd46f7ba13134d43411a2fa92b1b87061efac3",
+    "@atom/teletype-client": "https://github.com/atom/teletype-client#multi-buffer-sharing",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "https://github.com/atom/teletype-client#multi-buffer-sharing",
+    "@atom/teletype-client": "^0.29.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.28.2",
+    "@atom/teletype-client": "https://github.com/atom/teletype-client#e5dd46f7ba13134d43411a2fa92b1b87061efac3",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -369,7 +369,7 @@
   }
 
   &.upper-right {
-    top: @corner-margin;
+    top: @corner-margin * 3;
     display: flex;
     flex-direction: row;
     justify-content: flex-end;

--- a/test/buffer-binding.test.js
+++ b/test/buffer-binding.test.js
@@ -42,10 +42,42 @@ suite('BufferBinding', function () {
     assert.equal(bufferProxy.text, 'hello\nworld')
   })
 
+  suite('destroying the buffer', () => {
+    test('on the host, disposes the underlying buffer proxy', () => {
+      const buffer = new TextBuffer('')
+      const binding = new BufferBinding({buffer, isHost: true})
+      const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
+      binding.setBufferProxy(bufferProxy)
+
+      buffer.destroy()
+      assert(bufferProxy.disposed)
+    })
+
+    test('on guests, disposes the buffer binding', () => {
+      const buffer = new TextBuffer('')
+      const binding = new BufferBinding({buffer, isHost: false})
+      const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
+      binding.setBufferProxy(bufferProxy)
+
+      buffer.destroy()
+      assert(binding.disposed)
+      assert(!bufferProxy.disposed)
+    })
+  })
+
   class FakeBufferProxy {
     constructor (delegate, text) {
       this.delegate = delegate
       this.text = text
+      this.disposed = false
+    }
+
+    dispose () {
+      this.disposed = true
+    }
+
+    getHistory () {
+      return {undoStack: [], redoStack: [], nextCheckpointId: 1}
     }
 
     setTextInRange (oldStart, oldEnd, newText) {

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -301,6 +301,29 @@ suite('EditorBinding', function () {
     })
   })
 
+  suite('destroying the editor', () => {
+    test('on the host, disposes the underlying editor proxy', () => {
+      const editor = new TextEditor()
+      const binding = new EditorBinding({editor, isHost: true, portal: new FakePortal()})
+      const editorProxy = new FakeEditorProxy(binding)
+      binding.setEditorProxy(editorProxy)
+
+      editor.destroy()
+      assert(editorProxy.disposed)
+    })
+
+    test('on guests, disposes the editor binding', () => {
+      const editor = new TextEditor()
+      const binding = new EditorBinding({editor, isHost: false, portal: new FakePortal()})
+      const editorProxy = new FakeEditorProxy(binding)
+      binding.setEditorProxy(editorProxy)
+
+      editor.destroy()
+      assert(binding.disposed)
+      assert(!editorProxy.disposed)
+    })
+  })
+
   suite('guest editor binding', () => {
     test('overrides the editor methods when setting the proxy, and restores them on dispose', () => {
       const buffer = new TextBuffer({text: SAMPLE_TEXT})
@@ -450,6 +473,11 @@ class FakeEditorProxy {
     this.bufferProxy = {uri: 'fake-buffer-proxy-uri'}
     this.selections = {}
     this.siteId = (siteId == null) ? 1 : siteId
+    this.disposed = false
+  }
+
+  dispose () {
+    this.disposed = true
   }
 
   didScroll () {}

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -5,6 +5,7 @@ const SAMPLE_TEXT = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.js'
 const {TextEditor, TextBuffer, Range} = require('atom')
 const EditorBinding = require('../lib/editor-binding')
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
+const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
 const {
   setEditorHeightInLines,
   setEditorWidthInChars,
@@ -21,11 +22,7 @@ suite('EditorBinding', function () {
   setup(() => {
     // Load the editor default styles by instantiating a new AtomEnvironment.
     const environment = buildAtomEnvironment()
-    // Load also package style sheets, so that additional UI elements are styled
-    // correctly.
-    const packageStyleSheetPath = path.join(__dirname, '..', 'styles', 'teletype.less')
-    const compiledStyleSheet = environment.themes.loadStylesheet(packageStyleSheetPath)
-    environment.styles.addStyleSheet(compiledStyleSheet)
+    loadPackageStyleSheets(environment)
     // Position editor absolutely to prevent its size from being affected by the
     // window size of the test runner. We also give it an initial width and
     // height so that the editor component can perform initial measurements.

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -464,24 +464,6 @@ class FakeEditorProxy {
       }
     }
   }
-
-  follow (siteId) {
-    this.followedSiteId = siteId
-    this.followState = FollowState.RETRACTED
-  }
-
-  unfollow () {
-    this.followedSiteId = null
-    this.followState = FollowState.DISCONNECTED
-  }
-
-  getFollowedSiteId () {
-    if (this.followState === FollowState.DISCONNECTED) {
-      return null
-    } else {
-      return this.followedSiteId
-    }
-  }
 }
 
 class FakePortal {

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -416,11 +416,15 @@ suite('EditorBinding', function () {
     assert.equal(editorProxy.getFollowedSiteId(), null)
   })
 
-  test('isPositionVisible(position)', async () => {
+  test('isScrollNeededToViewPosition(position)', async () => {
     const editor = new TextEditor({autoHeight: false})
     const binding = new EditorBinding({editor, portal: new FakePortal()})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
+
+    // If the editor is not yet attached to the DOM, scrolling isn't gonna help.
+    assert(!binding.isScrollNeededToViewPosition({row: 1, column: 0}))
+    assert(!binding.isScrollNeededToViewPosition({row: 0, column: 9}))
 
     attachToDOM(editor.element)
     await setEditorHeightInLines(editor, 4)
@@ -428,9 +432,9 @@ suite('EditorBinding', function () {
 
     editor.setText('a pretty long line\n'.repeat(100))
 
-    assert(binding.isPositionVisible({row: 1, column: 0}))
-    assert(!binding.isPositionVisible({row: 0, column: 9}))
-    assert(!binding.isPositionVisible({row: 6, column: 0}))
+    assert(!binding.isScrollNeededToViewPosition({row: 1, column: 0}))
+    assert(binding.isScrollNeededToViewPosition({row: 0, column: 9}))
+    assert(binding.isScrollNeededToViewPosition({row: 6, column: 0}))
 
     // Ensure text is rendered, so that we can scroll down/right.
     await editor.component.getNextUpdatePromise()
@@ -438,9 +442,9 @@ suite('EditorBinding', function () {
     setEditorScrollTopInLines(editor, 5)
     setEditorScrollLeftInChars(editor, 5)
 
-    assert(binding.isPositionVisible({row: 6, column: 7}))
-    assert(!binding.isPositionVisible({row: 6, column: 0}))
-    assert(!binding.isPositionVisible({row: 3, column: 7}))
+    assert(!binding.isScrollNeededToViewPosition({row: 6, column: 7}))
+    assert(binding.isScrollNeededToViewPosition({row: 6, column: 0}))
+    assert(binding.isScrollNeededToViewPosition({row: 3, column: 7}))
   })
 
   test('destroys folds intersecting the position of the leader', async () => {

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -347,7 +347,8 @@ suite('EditorBinding', function () {
     assert.deepEqual(getCursorClasses(editor), [])
   })
 
-  test('showing the active position of other collaborators', async () => {
+  test.skip('showing the active position of other collaborators', async () => {
+    // TODO: move this test into portal binding tests.
     const editor = new TextEditor({autoHeight: false})
     editor.setText(SAMPLE_TEXT)
 

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -78,18 +78,17 @@ suite('GuestPortalBinding', () => {
       activePaneItemChangeEvents.push(item)
     })
 
-    portalBinding.setActiveEditorProxy(buildEditorProxy('uri-1'))
-    portalBinding.setActiveEditorProxy(buildEditorProxy('uri-2'))
-    portalBinding.setActiveEditorProxy(null)
-    await portalBinding.setActiveEditorProxy(buildEditorProxy('uri-3'))
+    portalBinding.activateEditorProxy(buildEditorProxy('uri-1'))
+    portalBinding.activateEditorProxy(buildEditorProxy('uri-2'))
+    await portalBinding.activateEditorProxy(buildEditorProxy('uri-3'))
 
     assert.deepEqual(
       activePaneItemChangeEvents.map((i) => i.getTitle()),
-      ['@some-host: uri-1', '@some-host: uri-2', '@some-host: No Active File', '@some-host: uri-3']
+      ['@some-host: uri-1', '@some-host: uri-2', '@some-host: uri-3']
     )
     assert.deepEqual(
       atomEnv.workspace.getPaneItems().map((i) => i.getTitle()),
-      ['@some-host: uri-3']
+      ['@some-host: uri-1', '@some-host: uri-2', '@some-host: uri-3']
     )
 
     disposable.dispose()

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
 const {FollowState, TeletypeClient} = require('@atom/teletype-client')
 const FakePortal = require('./helpers/fake-portal')
+const FakeEditorProxy = require('./helpers/fake-editor-proxy')
 const GuestPortalBinding = require('../lib/guest-portal-binding')
 
 suite('GuestPortalBinding', () => {
@@ -101,11 +102,13 @@ suite('GuestPortalBinding', () => {
     const rightPane = leftPane.splitRight({moveActiveItem: true})
     assert.equal(leftPane.getItems().length, 1)
     assert.equal(rightPane.getItems().length, 1)
+    assert.equal(atomEnv.workspace.getActivePane(), rightPane)
 
     leftPane.activate()
     await portalBinding.updateTether(FollowState.RETRACTED, editorProxy2)
     assert.equal(leftPane.getItems().length, 1)
     assert.equal(rightPane.getItems().length, 1)
+    assert.equal(atomEnv.workspace.getActivePane(), rightPane)
   })
 
   test('toggling site position components visibility when switching tabs', async () => {
@@ -135,26 +138,5 @@ suite('GuestPortalBinding', () => {
       notificationManager: atomEnv.notifications,
       workspace: atomEnv.workspace
     })
-  }
-
-  class FakeEditorProxy {
-    constructor (uri) {
-      this.bufferProxy = {
-        uri,
-        dispose () {},
-        setDelegate () {},
-        createCheckpoint () {},
-        groupChangesSinceCheckpoint () {},
-        applyGroupingInterval () {}
-      }
-    }
-
-    follow () {}
-
-    didScroll () {}
-
-    setDelegate () {}
-
-    updateSelections () {}
   }
 })

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
+const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
 const {FollowState, TeletypeClient} = require('@atom/teletype-client')
 const GuestPortalBinding = require('../lib/guest-portal-binding')
 const SAMPLE_TEXT = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.js'), 'utf8')
@@ -100,13 +101,7 @@ suite('GuestPortalBinding', () => {
   test('showing the active position of other collaborators', async () => {
     const environment = buildAtomEnvironment()
 
-    // TODO Extract helper: loadPackageStylesheets
-    // Load also package style sheets, so that additional UI elements are styled
-    // correctly.
-    const packageStyleSheetPath = path.join(__dirname, '..', 'styles', 'teletype.less')
-    const compiledStyleSheet = environment.themes.loadStylesheet(packageStyleSheetPath)
-    environment.styles.addStyleSheet(compiledStyleSheet)
-
+    loadPackageStyleSheets(environment)
     const {workspace} = environment
     attachToDOM(workspace.getElement())
 

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -33,6 +33,7 @@ suite('GuestPortalBinding', () => {
       setDelegate (delegate) {
         this.delegate = delegate
       },
+      activateEditorProxy () {},
       getSiteIdentity (siteId) {
         return {login: 'site-' + siteId}
       }

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -1,26 +1,11 @@
 const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
-const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
 const {FollowState, TeletypeClient} = require('@atom/teletype-client')
+const FakePortal = require('./helpers/fake-portal')
 const GuestPortalBinding = require('../lib/guest-portal-binding')
-const SAMPLE_TEXT = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.js'), 'utf8')
-const {
-  setEditorHeightInLines,
-  setEditorWidthInChars,
-  setEditorScrollTopInLines,
-  setEditorScrollLeftInChars
-} = require('./helpers/editor-helpers')
 
 suite('GuestPortalBinding', () => {
-  let attachedElements = []
-
   teardown(async () => {
-    while (attachedElements.length > 0) {
-      attachedElements.pop().remove()
-    }
-
     await destroyAtomEnvironments()
   })
 
@@ -98,114 +83,7 @@ suite('GuestPortalBinding', () => {
     disposable.dispose()
   })
 
-  test('showing the active position of other collaborators', async () => {
-    const environment = buildAtomEnvironment()
-
-    loadPackageStyleSheets(environment)
-    const {workspace} = environment
-    attachToDOM(workspace.getElement())
-
-    const client = {
-      joinPortal () {
-        return new FakePortal()
-      }
-    }
-    const portalBinding = buildGuestPortalBinding(client, environment, 'some-portal')
-    await portalBinding.initialize()
-
-    const editorProxy1 = new FakeEditorProxy('editor-1')
-    const editorProxy2 = new FakeEditorProxy('editor-2')
-    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy1)
-
-    const editor1 = workspace.getActiveTextEditor()
-    editor1.buffer.setTextInRange([[0, 0], [0, 0]], SAMPLE_TEXT, {undo: 'skip'})
-
-    const {
-      aboveViewportSitePositionsComponent,
-      insideViewportSitePositionsComponent,
-      outsideViewportSitePositionsComponent
-    } = portalBinding
-    assert(workspace.element.contains(aboveViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(insideViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(outsideViewportSitePositionsComponent.element))
-
-    await setEditorHeightInLines(editor1, 3)
-    await setEditorWidthInChars(editor1, 5)
-    await setEditorScrollTopInLines(editor1, 5)
-    await setEditorScrollLeftInChars(editor1, 5)
-
-    const activePositionsBySiteId = {
-      1: {editorProxy: editorProxy1, position: {row: 2, column: 5}}, // collaborator above visible area
-      2: {editorProxy: editorProxy1, position: {row: 9, column: 5}}, // collaborator below visible area
-      3: {editorProxy: editorProxy1, position: {row: 6, column: 1}}, // collaborator to the left of visible area
-      4: {editorProxy: editorProxy1, position: {row: 6, column: 15}}, // collaborator to the right of visible area
-      5: {editorProxy: editorProxy1, position: {row: 6, column: 6}}, // collaborator inside of visible area
-      6: {editorProxy: editorProxy2, position: {row: 0, column: 0}} // collaborator in a different editor
-    }
-    portalBinding.updateActivePositions(activePositionsBySiteId)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [5])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 3, 4, 6])
-
-    await setEditorScrollLeftInChars(editor1, 0)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 5, 6])
-
-    await setEditorScrollTopInLines(editor1, 2)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5, 6])
-
-    await setEditorHeightInLines(editor1, 7)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 4, 5, 6])
-
-    await setEditorWidthInChars(editor1, 10)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 6])
-
-    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy2)
-    portalBinding.updateActivePositions(activePositionsBySiteId)
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [6])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5])
-
-    // Selecting a site will follow them.
-    outsideViewportSitePositionsComponent.props.onSelectSiteId(2)
-    assert.equal(portalBinding.portal.getFollowedSiteId(), 2)
-
-    // Selecting the same site again will unfollow them.
-    outsideViewportSitePositionsComponent.props.onSelectSiteId(2)
-    assert.equal(portalBinding.portal.getFollowedSiteId(), null)
-
-    // Focusing a pane item that does not belong to the portal will hide site positions.
-    await workspace.open()
-
-    assert(!workspace.element.contains(aboveViewportSitePositionsComponent.element))
-    assert(!workspace.element.contains(insideViewportSitePositionsComponent.element))
-    assert(!workspace.element.contains(outsideViewportSitePositionsComponent.element))
-
-    // Focusing a pane item that belongs to the portal will show site positions again.
-    await workspace.open(editor1)
-    portalBinding.updateActivePositions(activePositionsBySiteId)
-
-    assert(workspace.element.contains(aboveViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(insideViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(outsideViewportSitePositionsComponent.element))
-
-    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
-    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
-    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 6])
-  })
+  test('toggling site position components visibility when switching tabs')
 
   function buildGuestPortalBinding (client, atomEnv, portalId) {
     return new GuestPortalBinding({
@@ -214,11 +92,6 @@ suite('GuestPortalBinding', () => {
       notificationManager: atomEnv.notifications,
       workspace: atomEnv.workspace
     })
-  }
-
-  function attachToDOM (element) {
-    attachedElements.push(element)
-    document.body.insertBefore(element, document.body.firstChild)
   }
 
   class FakeEditorProxy {
@@ -240,29 +113,5 @@ suite('GuestPortalBinding', () => {
     setDelegate () {}
 
     updateSelections () {}
-  }
-
-  class FakePortal {
-    follow (siteId) {
-      this.followedSiteId = siteId
-    }
-
-    unfollow () {
-      this.followedSiteId = null
-    }
-
-    getFollowedSiteId () {
-      return this.followedSiteId
-    }
-
-    activateEditorProxy () {}
-
-    setDelegate (delegate) {
-      this.delegate = delegate
-    }
-
-    getSiteIdentity (siteId) {
-      return {login: 'site-' + siteId}
-    }
   }
 })

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -83,6 +83,31 @@ suite('GuestPortalBinding', () => {
     disposable.dispose()
   })
 
+  test('switching the active editor to a remote editor that had been moved into a non-active pane', async () => {
+    const stubPubSubGateway = {}
+    const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})
+    client.joinPortal = () => new FakePortal()
+    const atomEnv = buildAtomEnvironment()
+    const portalBinding = buildGuestPortalBinding(client, atomEnv, 'some-portal')
+    await portalBinding.initialize()
+
+    const editorProxy1 = new FakeEditorProxy('editor-1')
+    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy1)
+
+    const editorProxy2 = new FakeEditorProxy('editor-2')
+    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy2)
+
+    const leftPane = atomEnv.workspace.getActivePane()
+    const rightPane = leftPane.splitRight({moveActiveItem: true})
+    assert.equal(leftPane.getItems().length, 1)
+    assert.equal(rightPane.getItems().length, 1)
+
+    leftPane.activate()
+    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy2)
+    assert.equal(leftPane.getItems().length, 1)
+    assert.equal(rightPane.getItems().length, 1)
+  })
+
   test('toggling site position components visibility when switching tabs', async () => {
     const stubPubSubGateway = {}
     const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -173,6 +173,7 @@ suite('GuestPortalBinding', () => {
     await portalBinding.removeEditorProxy(editorProxy1)
     assert.equal(portal.getFollowedSiteId(), 1)
     assert.equal(portal.resolveFollowState(), FollowState.RETRACTED)
+    assert(!portal.disposed)
   })
 
   test('toggling site position components visibility when switching tabs', async () => {

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -167,7 +167,6 @@ suite('GuestPortalBinding', () => {
 
     const editorProxy = new FakeEditorProxy('some-uri')
     await portalBinding.updateTether(FollowState.RETRACTED, editorProxy)
-    const portalPaneItem = atomEnv.workspace.getActivePaneItem()
     assert.equal(portalBinding.sitePositionsController.visible, true)
 
     await atomEnv.workspace.open(localPaneItem1)

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -151,6 +151,30 @@ suite('GuestPortalBinding', () => {
     assert(atomEnv.workspace.getActivePaneItem().getTitle().includes('editor-1'))
   })
 
+  test('host closing last remote editor on guest workspace', async () => {
+    const portal = new FakePortal()
+    const client = {joinPortal: () => portal}
+    const atomEnv = buildAtomEnvironment()
+    const portalBinding = buildGuestPortalBinding(client, atomEnv, 'some-portal')
+
+    await portalBinding.initialize()
+    portal.setFollowState(FollowState.RETRACTED)
+
+    const editorProxy1 = new FakeEditorProxy('editor-1')
+    await portalBinding.updateTether(FollowState.RETRACTED, editorProxy1)
+
+    const editorProxy2 = new FakeEditorProxy('editor-2')
+    portal.setFollowState(FollowState.DISCONNECTED)
+    await portalBinding.updateTether(FollowState.DISCONNECTED)
+
+    await portalBinding.removeEditorProxy(editorProxy2)
+    assert.equal(portal.resolveFollowState(), FollowState.DISCONNECTED)
+
+    await portalBinding.removeEditorProxy(editorProxy1)
+    assert.equal(portal.getFollowedSiteId(), 1)
+    assert.equal(portal.resolveFollowState(), FollowState.RETRACTED)
+  })
+
   test('toggling site position components visibility when switching tabs', async () => {
     const stubPubSubGateway = {}
     const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -117,8 +117,8 @@ suite('GuestPortalBinding', () => {
     const editorProxy2 = new FakeEditorProxy('editor-2')
     await portalBinding.updateTether(FollowState.RETRACTED, editorProxy1)
 
-    const editor = workspace.getActiveTextEditor()
-    editor.buffer.setTextInRange([[0, 0], [0, 0]], SAMPLE_TEXT, {undo: 'skip'})
+    const editor1 = workspace.getActiveTextEditor()
+    editor1.buffer.setTextInRange([[0, 0], [0, 0]], SAMPLE_TEXT, {undo: 'skip'})
 
     const {
       aboveViewportSitePositionsComponent,
@@ -129,10 +129,10 @@ suite('GuestPortalBinding', () => {
     assert(workspace.element.contains(insideViewportSitePositionsComponent.element))
     assert(workspace.element.contains(outsideViewportSitePositionsComponent.element))
 
-    await setEditorHeightInLines(editor, 3)
-    await setEditorWidthInChars(editor, 5)
-    await setEditorScrollTopInLines(editor, 5)
-    await setEditorScrollLeftInChars(editor, 5)
+    await setEditorHeightInLines(editor1, 3)
+    await setEditorWidthInChars(editor1, 5)
+    await setEditorScrollTopInLines(editor1, 5)
+    await setEditorScrollLeftInChars(editor1, 5)
 
     const activePositionsBySiteId = {
       1: {editorProxy: editorProxy1, position: {row: 2, column: 5}}, // collaborator above visible area
@@ -148,25 +148,25 @@ suite('GuestPortalBinding', () => {
     assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [5])
     assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 3, 4, 6])
 
-    await setEditorScrollLeftInChars(editor, 0)
+    await setEditorScrollLeftInChars(editor1, 0)
 
     assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])
     assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
     assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 5, 6])
 
-    await setEditorScrollTopInLines(editor, 2)
+    await setEditorScrollTopInLines(editor1, 2)
 
     assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
     assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [])
     assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5, 6])
 
-    await setEditorHeightInLines(editor, 7)
+    await setEditorHeightInLines(editor1, 7)
 
     assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
     assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
     assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 4, 5, 6])
 
-    await setEditorWidthInChars(editor, 10)
+    await setEditorWidthInChars(editor1, 10)
 
     assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
     assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
@@ -189,15 +189,22 @@ suite('GuestPortalBinding', () => {
 
     // Focusing a pane item that does not belong to the portal will hide site positions.
     await workspace.open()
+
     assert(!workspace.element.contains(aboveViewportSitePositionsComponent.element))
     assert(!workspace.element.contains(insideViewportSitePositionsComponent.element))
     assert(!workspace.element.contains(outsideViewportSitePositionsComponent.element))
 
-    // Re-focusing a pane item that belongs to the portal will show site positions again.
-    await workspace.open(editor)
+    // Focusing a pane item that belongs to the portal will show site positions again.
+    await workspace.open(editor1)
+    portalBinding.updateActivePositions(activePositionsBySiteId)
+
     assert(workspace.element.contains(aboveViewportSitePositionsComponent.element))
     assert(workspace.element.contains(insideViewportSitePositionsComponent.element))
     assert(workspace.element.contains(outsideViewportSitePositionsComponent.element))
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 6])
   })
 
   function buildGuestPortalBinding (client, atomEnv, portalId) {

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -83,7 +83,25 @@ suite('GuestPortalBinding', () => {
     disposable.dispose()
   })
 
-  test('toggling site position components visibility when switching tabs')
+  test('toggling site position components visibility when switching tabs', async () => {
+    const stubPubSubGateway = {}
+    const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})
+    const portal = new FakePortal()
+    client.joinPortal = () => portal
+    const atomEnv = buildAtomEnvironment()
+    const portalBinding = buildGuestPortalBinding(client, atomEnv, 'some-portal')
+    await portalBinding.initialize()
+
+    await portalBinding.updateTether(FollowState.RETRACTED, new FakeEditorProxy('some-uri'))
+    const portalPaneItem = atomEnv.workspace.getActivePaneItem()
+    assert.equal(portalBinding.sitePositionsController.visible, true)
+
+    await atomEnv.workspace.open()
+    assert.equal(portalBinding.sitePositionsController.visible, false)
+
+    await atomEnv.workspace.open(portalPaneItem)
+    assert.equal(portalBinding.sitePositionsController.visible, true)
+  })
 
   function buildGuestPortalBinding (client, atomEnv, portalId) {
     return new GuestPortalBinding({

--- a/test/guest-portal-binding.test.js
+++ b/test/guest-portal-binding.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
-const {TeletypeClient} = require('@atom/teletype-client')
+const {FollowState, TeletypeClient} = require('@atom/teletype-client')
 const GuestPortalBinding = require('../lib/guest-portal-binding')
 
 suite('GuestPortalBinding', () => {
@@ -78,9 +78,9 @@ suite('GuestPortalBinding', () => {
       activePaneItemChangeEvents.push(item)
     })
 
-    portalBinding.activateEditorProxy(buildEditorProxy('uri-1'))
-    portalBinding.activateEditorProxy(buildEditorProxy('uri-2'))
-    await portalBinding.activateEditorProxy(buildEditorProxy('uri-3'))
+    portalBinding.updateTether(FollowState.RETRACTED, buildEditorProxy('uri-1'))
+    portalBinding.updateTether(FollowState.RETRACTED, buildEditorProxy('uri-2'))
+    await portalBinding.updateTether(FollowState.RETRACTED, buildEditorProxy('uri-3'))
 
     assert.deepEqual(
       activePaneItemChangeEvents.map((i) => i.getTitle()),

--- a/test/helpers/editor-helpers.js
+++ b/test/helpers/editor-helpers.js
@@ -1,0 +1,22 @@
+exports.setEditorHeightInLines = async function setEditorHeightInLines (editor, lines) {
+  editor.element.style.height = editor.getLineHeightInPixels() * lines + 'px'
+  return editor.component.getNextUpdatePromise()
+}
+
+exports.setEditorWidthInChars = async function setEditorWidthInChars (editor, chars) {
+  editor.element.style.width =
+    editor.component.getGutterContainerWidth() +
+    chars * editor.getDefaultCharWidth() +
+    'px'
+  return editor.component.getNextUpdatePromise()
+}
+
+exports.setEditorScrollTopInLines = async function setEditorScrollTopInLines (editor, lines) {
+  editor.element.setScrollTop(editor.getLineHeightInPixels() * lines)
+  return editor.component.getNextUpdatePromise()
+}
+
+exports.setEditorScrollLeftInChars = async function setEditorScrollLeftInChars (editor, chars) {
+  editor.element.setScrollLeft(editor.getDefaultCharWidth() * chars)
+  return editor.component.getNextUpdatePromise()
+}

--- a/test/helpers/fake-editor-proxy.js
+++ b/test/helpers/fake-editor-proxy.js
@@ -11,11 +11,17 @@ class FakeEditorProxy {
     }
   }
 
+  dispose () {
+    if (this.delegate) this.delegate.dispose()
+  }
+
   follow () {}
 
   didScroll () {}
 
-  setDelegate () {}
+  setDelegate (delegate) {
+    this.delegate = delegate
+  }
 
   updateSelections () {}
 }

--- a/test/helpers/fake-editor-proxy.js
+++ b/test/helpers/fake-editor-proxy.js
@@ -7,7 +7,10 @@ class FakeEditorProxy {
       setDelegate () {},
       createCheckpoint () {},
       groupChangesSinceCheckpoint () {},
-      applyGroupingInterval () {}
+      applyGroupingInterval () {},
+      getHistory () {
+        return {undoStack: [], redoStack: [], nextCheckpointId: 1}
+      }
     }
   }
 

--- a/test/helpers/fake-editor-proxy.js
+++ b/test/helpers/fake-editor-proxy.js
@@ -1,0 +1,21 @@
+module.exports =
+class FakeEditorProxy {
+  constructor (uri) {
+    this.bufferProxy = {
+      uri,
+      dispose () {},
+      setDelegate () {},
+      createCheckpoint () {},
+      groupChangesSinceCheckpoint () {},
+      applyGroupingInterval () {}
+    }
+  }
+
+  follow () {}
+
+  didScroll () {}
+
+  setDelegate () {}
+
+  updateSelections () {}
+}

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -9,14 +9,21 @@ class FakePortal {
   createBufferProxy () {
     return {
       dispose () {},
-      setDelegate () {}
+      setDelegate () {},
+      createCheckpoint () {},
+      groupChangesSinceCheckpoint () {},
+      applyGroupingInterval () {}
     }
   }
 
   createEditorProxy () {
     return {
-      dispose () {},
-      setDelegate () {},
+      dispose () {
+        this.delegate.dispose()
+      },
+      setDelegate (delegate) {
+        this.delegate = delegate
+      },
       updateSelections () {}
     }
   }

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -27,9 +27,15 @@ class FakePortal {
     return this.followedSiteId
   }
 
-  activateEditorProxy () {}
+  activateEditorProxy (editorProxy) {
+    this.activeEditorProxy = editorProxy
+  }
 
   removeEditorProxy () {}
+
+  getActiveEditorProxy () {
+    return this.activeEditorProxy
+  }
 
   setDelegate (delegate) {
     this.delegate = delegate

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -1,0 +1,24 @@
+module.exports =
+class FakePortal {
+  follow (siteId) {
+    this.followedSiteId = siteId
+  }
+
+  unfollow () {
+    this.followedSiteId = null
+  }
+
+  getFollowedSiteId () {
+    return this.followedSiteId
+  }
+
+  activateEditorProxy () {}
+
+  setDelegate (delegate) {
+    this.delegate = delegate
+  }
+
+  getSiteIdentity (siteId) {
+    return {login: 'site-' + siteId}
+  }
+}

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -1,5 +1,20 @@
 module.exports =
 class FakePortal {
+  createBufferProxy () {
+    return {
+      dispose () {},
+      setDelegate () {}
+    }
+  }
+
+  createEditorProxy () {
+    return {
+      dispose () {},
+      setDelegate () {},
+      updateSelections () {}
+    }
+  }
+
   follow (siteId) {
     this.followedSiteId = siteId
   }
@@ -13,6 +28,8 @@ class FakePortal {
   }
 
   activateEditorProxy () {}
+
+  removeEditorProxy () {}
 
   setDelegate (delegate) {
     this.delegate = delegate

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -7,6 +7,8 @@ class FakePortal {
     this.activeEditorProxyChangeCount = 0
   }
 
+  dispose () {}
+
   createBufferProxy () {
     return {
       dispose () {},

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -1,4 +1,5 @@
 const {FollowState} = require('@atom/teletype-client')
+const FakeEditorProxy = require('./fake-editor-proxy')
 
 module.exports =
 class FakePortal {
@@ -17,15 +18,7 @@ class FakePortal {
   }
 
   createEditorProxy () {
-    return {
-      dispose () {
-        this.delegate.dispose()
-      },
-      setDelegate (delegate) {
-        this.delegate = delegate
-      },
-      updateSelections () {}
-    }
+    return new FakeEditorProxy()
   }
 
   follow (siteId) {

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -1,5 +1,11 @@
+const {FollowState} = require('@atom/teletype-client')
+
 module.exports =
 class FakePortal {
+  constructor () {
+    this.activeEditorProxyChangeCount = 0
+  }
+
   createBufferProxy () {
     return {
       dispose () {},
@@ -17,10 +23,20 @@ class FakePortal {
 
   follow (siteId) {
     this.followedSiteId = siteId
+    this.setFollowState(FollowState.RETRACTED)
   }
 
   unfollow () {
     this.followedSiteId = null
+    this.setFollowState(FollowState.DISCONNECTED)
+  }
+
+  setFollowState (followState) {
+    this.followState = followState
+  }
+
+  resolveFollowState () {
+    return this.followState
   }
 
   getFollowedSiteId () {
@@ -29,6 +45,7 @@ class FakePortal {
 
   activateEditorProxy (editorProxy) {
     this.activeEditorProxy = editorProxy
+    this.activeEditorProxyChangeCount++
   }
 
   removeEditorProxy () {}

--- a/test/helpers/ui-helpers.js
+++ b/test/helpers/ui-helpers.js
@@ -1,0 +1,9 @@
+const path = require('path')
+
+// Load package style sheets for the given environment so that the package's
+// UI elements are styled correctly.
+exports.loadPackageStyleSheets = function (environment) {
+  const packageStyleSheetPath = path.join(__dirname, '..', '..', 'styles', 'teletype.less')
+  const compiledStyleSheet = environment.themes.loadStylesheet(packageStyleSheetPath)
+  environment.styles.addStyleSheet(compiledStyleSheet)
+}

--- a/test/host-portal-binding.test.js
+++ b/test/host-portal-binding.test.js
@@ -57,6 +57,9 @@ suite('HostPortalBinding', () => {
     assert(atomEnv.notifications.getNotifications()[0].message.includes('@site-3'))
   })
 
+  // TODO
+  test('toggling site position components visibility when switching between shared and non-shared pane items')
+
   function buildHostPortalBinding (client, atomEnv) {
     return new HostPortalBinding({
       client,

--- a/test/host-portal-binding.test.js
+++ b/test/host-portal-binding.test.js
@@ -3,6 +3,7 @@ const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-
 const {TeletypeClient} = require('@atom/teletype-client')
 const HostPortalBinding = require('../lib/host-portal-binding')
 const FakeClipboard = require('./helpers/fake-clipboard')
+const FakePortal = require('./helpers/fake-portal')
 
 suite('HostPortalBinding', () => {
   teardown(async () => {
@@ -10,8 +11,7 @@ suite('HostPortalBinding', () => {
   })
 
   test('handling an unexpected error when joining a portal', async () => {
-    const stubPubSubGateway = {}
-    const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})
+    const client = new TeletypeClient({pubSubGateway: {}})
     client.createPortal = function () {
       throw new Error('It broke!')
     }
@@ -28,17 +28,8 @@ suite('HostPortalBinding', () => {
   })
 
   test('showing notifications when sites join or leave', async () => {
-    const stubPubSubGateway = {}
-    const client = new TeletypeClient({pubSubGateway: stubPubSubGateway})
-    const portal = {
-      setDelegate (delegate) {
-        this.delegate = delegate
-      },
-      getSiteIdentity (siteId) {
-        return {login: 'site-' + siteId}
-      },
-      setActiveEditorProxy () {}
-    }
+    const portal = new FakePortal()
+    const client = new TeletypeClient({pubSubGateway: {}})
     client.createPortal = function () {
       return portal
     }

--- a/test/host-portal-binding.test.js
+++ b/test/host-portal-binding.test.js
@@ -5,7 +5,6 @@ const {FollowState, TeletypeClient} = require('@atom/teletype-client')
 const HostPortalBinding = require('../lib/host-portal-binding')
 const FakeClipboard = require('./helpers/fake-clipboard')
 const FakePortal = require('./helpers/fake-portal')
-const FakeEditorProxy = require('./helpers/fake-editor-proxy')
 
 suite('HostPortalBinding', () => {
   teardown(async () => {
@@ -58,10 +57,8 @@ suite('HostPortalBinding', () => {
     const portalBinding = buildHostPortalBinding(client, atomEnv)
     await portalBinding.initialize()
 
-    const editor1 = await atomEnv.workspace.open()
-    const editorProxy1 = portal.getActiveEditorProxy()
-
-    const editor2 = await atomEnv.workspace.open()
+    await atomEnv.workspace.open()
+    await atomEnv.workspace.open()
     const editorProxy2 = portal.getActiveEditorProxy()
 
     const leftPane = atomEnv.workspace.getActivePane()

--- a/test/portal-binding-manager.test.js
+++ b/test/portal-binding-manager.test.js
@@ -106,6 +106,9 @@ function buildPortalBindingManager () {
 
   const workspace = {
     element: document.createElement('div'),
+    async open () {
+
+    },
     getElement () {
       return this.element
     },
@@ -114,14 +117,21 @@ function buildPortalBindingManager () {
     },
     observeActivePaneItem () {
       return new Disposable(() => {})
+    },
+    onDidDestroyPaneItem () {
+      return new Disposable(() => {})
     }
   }
 
   return new PortalBindingManager({client, workspace, notificationManager})
 }
 
+let nextIdentityId = 1
 function buildPortal () {
   return {
+    getSiteIdentity () {
+      return {login: 'identity-' + nextIdentityId++}
+    },
     dispose () {
       this.delegate.dispose()
     },

--- a/test/portal-binding-manager.test.js
+++ b/test/portal-binding-manager.test.js
@@ -118,6 +118,9 @@ function buildPortalBindingManager () {
     observeActivePaneItem () {
       return new Disposable(() => {})
     },
+    onDidChangeActivePaneItem () {
+      return new Disposable(() => {})
+    },
     onDidDestroyPaneItem () {
       return new Disposable(() => {})
     }

--- a/test/portal-binding-manager.test.js
+++ b/test/portal-binding-manager.test.js
@@ -1,8 +1,12 @@
 const assert = require('assert')
-const {Disposable} = require('atom')
+const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
 const PortalBindingManager = require('../lib/portal-binding-manager')
 
 suite('PortalBindingManager', () => {
+  teardown(async () => {
+    await destroyAtomEnvironments()
+  })
+
   suite('host portal binding', () => {
     test('idempotently creating the host portal binding', async () => {
       const manager = buildPortalBindingManager()
@@ -85,6 +89,7 @@ suite('PortalBindingManager', () => {
 })
 
 function buildPortalBindingManager () {
+  const {workspace, notifications: notificationManager} = buildAtomEnvironment()
   const client = {
     resolveLastCreatePortalPromise: null,
     resolveLastJoinPortalPromise: null,
@@ -95,43 +100,13 @@ function buildPortalBindingManager () {
       return new Promise((resolve) => { this.resolveLastJoinPortalPromise = resolve })
     }
   }
-
-  const notificationManager = {
-    addInfo () {},
-    addSuccess () {},
-    addError (error, options) {
-      throw new Error(error + '\n' + options.description)
-    }
-  }
-
-  const workspace = {
-    element: document.createElement('div'),
-    async open () {
-
-    },
-    getElement () {
-      return this.element
-    },
-    observeActiveTextEditor () {
-      return new Disposable(() => {})
-    },
-    observeActivePaneItem () {
-      return new Disposable(() => {})
-    },
-    onDidChangeActivePaneItem () {
-      return new Disposable(() => {})
-    },
-    onDidDestroyPaneItem () {
-      return new Disposable(() => {})
-    }
-  }
-
   return new PortalBindingManager({client, workspace, notificationManager})
 }
 
 let nextIdentityId = 1
 function buildPortal () {
   return {
+    activateEditorProxy () {},
     getSiteIdentity () {
       return {login: 'identity-' + nextIdentityId++}
     },

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -254,6 +254,12 @@ class FakeWorkspace {
   observeActiveTextEditor () {
     return new Disposable(() => {})
   }
+
+  onDidDestroyPaneItem () {
+    return new Disposable(() => {})
+  }
+
+  paneForItem () {}
 }
 
 class FakeNotificationManager {

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -247,6 +247,16 @@ suite('PortalListComponent', function () {
 class FakeWorkspace {
   async open () {}
 
+  getCenter () {
+    return {
+      paneContainer: {
+        getElement () {
+          return document.createElement('div')
+        }
+      }
+    }
+  }
+
   getElement () {
     return document.createElement('div')
   }

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -259,6 +259,10 @@ class FakeWorkspace {
     return new Disposable(() => {})
   }
 
+  onDidChangeActivePaneItem () {
+    return new Disposable(() => {})
+  }
+
   paneForItem () {}
 }
 

--- a/test/site-positions-controller.test.js
+++ b/test/site-positions-controller.test.js
@@ -1,0 +1,164 @@
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
+const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
+const {
+  setEditorHeightInLines,
+  setEditorWidthInChars,
+  setEditorScrollTopInLines,
+  setEditorScrollLeftInChars
+} = require('./helpers/editor-helpers')
+const {TextEditor, TextBuffer} = require('atom')
+const SAMPLE_TEXT = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.js'), 'utf8')
+const FakePortal = require('./helpers/fake-portal')
+
+const EditorBinding = require('../lib/editor-binding')
+const SitePositionsController = require('../lib/site-positions-controller')
+
+suite('SitePositionsController', () => {
+  let attachedElements = []
+
+  teardown(async () => {
+    while (attachedElements.length > 0) {
+      attachedElements.pop().remove()
+    }
+
+    await destroyAtomEnvironments()
+  })
+
+  test('show() and hide()', async () => {
+    const {workspace} = buildAtomEnvironment()
+    const controller = new SitePositionsController({
+      workspace,
+      portal: {},
+      editorBindingForEditorProxy: () => {}
+    })
+
+    controller.show()
+    assert(workspace.element.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(workspace.element.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(workspace.element.contains(controller.outsideViewportSitePositionsComponent.element))
+
+    controller.hide()
+    assert(!workspace.element.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(!workspace.element.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(!workspace.element.contains(controller.outsideViewportSitePositionsComponent.element))
+  })
+
+  test('updateActivePositions(positionsBySiteId)', async () => {
+    const environment = buildAtomEnvironment()
+    loadPackageStyleSheets(environment)
+    const {workspace} = environment
+    attachToDOM(workspace.getElement())
+
+    const portal = new FakePortal()
+    const controller = new SitePositionsController({workspace, portal})
+
+    const editorProxy1 = new FakeEditorProxy()
+    const editor1 = new TextEditor({autoHeight: false, buffer: new TextBuffer(SAMPLE_TEXT)})
+    const editorBinding1 = new EditorBinding({portal, editor: editor1})
+    editorBinding1.setEditorProxy(editorProxy1)
+    controller.addEditorBinding(editorBinding1)
+
+    const editorProxy2 = new FakeEditorProxy()
+    const editor2 = new TextEditor({autoHeight: false, buffer: new TextBuffer(SAMPLE_TEXT)})
+    const editorBinding2 = new EditorBinding({portal, editor: editor2})
+    editorBinding2.setEditorProxy(editorProxy2)
+    controller.addEditorBinding(editorBinding2)
+
+    const {
+      aboveViewportSitePositionsComponent,
+      insideViewportSitePositionsComponent,
+      outsideViewportSitePositionsComponent
+    } = controller
+
+    await workspace.open(editor1)
+    await setEditorHeightInLines(editor1, 3)
+    await setEditorWidthInChars(editor1, 5)
+    await setEditorScrollTopInLines(editor1, 5)
+    await setEditorScrollLeftInChars(editor1, 5)
+
+    const activePositionsBySiteId = {
+      1: {editorProxy: editorProxy1, position: {row: 2, column: 5}}, // collaborator above visible area
+      2: {editorProxy: editorProxy1, position: {row: 9, column: 5}}, // collaborator below visible area
+      3: {editorProxy: editorProxy1, position: {row: 6, column: 1}}, // collaborator to the left of visible area
+      4: {editorProxy: editorProxy1, position: {row: 6, column: 15}}, // collaborator to the right of visible area
+      5: {editorProxy: editorProxy1, position: {row: 6, column: 6}}, // collaborator inside of visible area
+      6: {editorProxy: editorProxy2, position: {row: 0, column: 0}} // collaborator in a different editor
+    }
+    controller.updateActivePositions(activePositionsBySiteId)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [5])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 3, 4, 6])
+
+    await setEditorScrollLeftInChars(editor1, 0)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [1])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 5, 6])
+
+    await setEditorScrollTopInLines(editor1, 2)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5, 6])
+
+    await setEditorHeightInLines(editor1, 7)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [3])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 4, 5, 6])
+
+    await setEditorWidthInChars(editor1, 10)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 6])
+
+    await workspace.open(editor2)
+    controller.updateActivePositions(activePositionsBySiteId)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [6])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5])
+
+    await workspace.open(new TextEditor())
+    controller.updateActivePositions(activePositionsBySiteId)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [1, 2, 3, 4, 5, 6])
+
+    await workspace.open(editor1)
+    controller.updateActivePositions(activePositionsBySiteId)
+
+    assert.deepEqual(aboveViewportSitePositionsComponent.props.siteIds, [])
+    assert.deepEqual(insideViewportSitePositionsComponent.props.siteIds, [1, 3, 5])
+    assert.deepEqual(outsideViewportSitePositionsComponent.props.siteIds, [2, 4, 6])
+
+    // Selecting a site will follow them.
+    outsideViewportSitePositionsComponent.props.onSelectSiteId(42)
+    assert.equal(controller.portal.getFollowedSiteId(), 42)
+
+    // Selecting the same site again will unfollow them.
+    outsideViewportSitePositionsComponent.props.onSelectSiteId(42)
+    assert.equal(controller.portal.getFollowedSiteId(), null)
+  })
+
+  function attachToDOM (element) {
+    attachedElements.push(element)
+    document.body.insertBefore(element, document.body.firstChild)
+  }
+})
+
+class FakeEditorProxy {
+  constructor () {
+    this.bufferProxy = {uri: 'fake-buffer-proxy-uri'}
+  }
+
+  didScroll () {}
+
+  updateSelections () {}
+}

--- a/test/site-positions-controller.test.js
+++ b/test/site-positions-controller.test.js
@@ -35,15 +35,17 @@ suite('SitePositionsController', () => {
       editorBindingForEditorProxy: () => {}
     })
 
+    const workspaceCenterElement = workspace.getCenter().paneContainer.getElement()
+
     controller.show()
-    assert(workspace.element.contains(controller.aboveViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(controller.insideViewportSitePositionsComponent.element))
-    assert(workspace.element.contains(controller.outsideViewportSitePositionsComponent.element))
+    assert(workspaceCenterElement.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(workspaceCenterElement.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(workspaceCenterElement.contains(controller.outsideViewportSitePositionsComponent.element))
 
     controller.hide()
-    assert(!workspace.element.contains(controller.aboveViewportSitePositionsComponent.element))
-    assert(!workspace.element.contains(controller.insideViewportSitePositionsComponent.element))
-    assert(!workspace.element.contains(controller.outsideViewportSitePositionsComponent.element))
+    assert(!workspaceCenterElement.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(!workspaceCenterElement.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(!workspaceCenterElement.contains(controller.outsideViewportSitePositionsComponent.element))
   })
 
   test('updateActivePositions(positionsBySiteId)', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -88,6 +88,7 @@ suite('TeletypePackage', function () {
       [[0, 5], [0, 7]]
     ])
     await condition(() => deepEqual(getCursorDecoratedRanges(hostEditor1), getCursorDecoratedRanges(guestEditor1)))
+    await timeout(guestPackage.tetherDisconnectWindow)
 
     const hostEditor2 = await hostEnv.workspace.open(temp.path({extension: '.md'}))
     hostEditor2.setText('# Hello, World')
@@ -197,7 +198,11 @@ suite('TeletypePackage', function () {
     // Portal 2 host continues to exist as a guest in Portal 1
     hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-2'))
     const guestAndHostRemotePaneItem2 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
+    // TODO Remove sorting. Order should be guaranteed.
+    assert.deepEqual(
+      getPaneItems(guestAndHostEnv).sort((a, b) => a.id - b.id),
+      [guestAndHostRemotePaneItem1, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2].sort((a, b) => a.id - b.id)
+    )
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // No transitivity: When Portal 2 host is viewing contents of Portal 1, Portal 2 guests can only see contents of Portal 2
@@ -208,7 +213,11 @@ suite('TeletypePackage', function () {
     // As Portal 2 host observes changes in Portal 1, Portal 2 guests continue to only see contents of Portal 2
     await hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-3'))
     const guestAndHostRemotePaneItem3 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
+    // TODO Remove sorting. Order should be guaranteed.
+    assert.deepEqual(
+      getPaneItems(guestAndHostEnv).sort((a, b) => a.id - b.id),
+      [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2].sort((a, b) => a.id - b.id)
+    )
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // When Portal 2 host shares another local buffer, Portal 2 guests see that buffer
@@ -698,6 +707,7 @@ suite('TeletypePackage', function () {
     guestEditor2.setCursorBufferPosition([0, Infinity])
     guestEditor2.insertText('\nconst goodbye = "moon"')
     await editorsEqual(guestEditor2, hostEditor2)
+    await timeout(guestPackage.tetherDisconnectWindow)
 
     hostEditor2.undo()
     assert.equal(hostEditor2.getText(), 'hello = "world"\nconst goodbye = "moon"')
@@ -799,29 +809,31 @@ suite('TeletypePackage', function () {
     await condition(() => guestEditor1.lineTextForBufferRow(1).includes('y'))
     assert(guestEditor1.getCursorBufferPosition().isEqual([20, 29]))
 
+    // TODO Update tests below to reflect new behavior
+
     // Reconnect and retract the tether when the host switches editors
-    const hostEditor2 = await hostEnv.workspace.open()
-    hostEditor2.setText(('y'.repeat(30) + '\n').repeat(30))
-    hostEditor2.setCursorBufferPosition([2, 2])
-    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
-    await condition(() => deepEqual(guestEditor2.getCursorBufferPosition(), hostEditor2.getCursorBufferPosition()))
-    hostEditor2.setCursorBufferPosition([4, 4])
-    await condition(() => deepEqual(guestEditor2.getCursorBufferPosition(), hostEditor2.getCursorBufferPosition()))
+    // const hostEditor2 = await hostEnv.workspace.open()
+    // hostEditor2.setText(('y'.repeat(30) + '\n').repeat(30))
+    // hostEditor2.setCursorBufferPosition([2, 2])
+    // const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
+    // await condition(() => deepEqual(guestEditor2.getCursorBufferPosition(), hostEditor2.getCursorBufferPosition()))
+    // hostEditor2.setCursorBufferPosition([4, 4])
+    // await condition(() => deepEqual(guestEditor2.getCursorBufferPosition(), hostEditor2.getCursorBufferPosition()))
 
     // Disconnect tether if guest scrolls the tether position out of view
-    guestEditor2.setCursorBufferPosition([20, 0])
-    await timeout(guestPackage.tetherDisconnectWindow)
-    hostEditor2.setCursorBufferPosition([4, 5])
-    hostEditor2.insertText('z')
-    await condition(() => guestEditor2.lineTextForBufferRow(4).includes('z'))
-    assert(guestEditor2.getCursorBufferPosition().isEqual([20, 0]))
+    // guestEditor2.setCursorBufferPosition([20, 0])
+    // await timeout(guestPackage.tetherDisconnectWindow)
+    // hostEditor2.setCursorBufferPosition([4, 5])
+    // hostEditor2.insertText('z')
+    // await condition(() => guestEditor2.lineTextForBufferRow(4).includes('z'))
+    // assert(guestEditor2.getCursorBufferPosition().isEqual([20, 0]))
 
     // When host switches back to an existing editor, reconnect the tether
-    hostEnv.workspace.getActivePane().activateItem(hostEditor1)
-    await getNextActiveTextEditorPromise(guestEnv)
-    await condition(() => deepEqual(guestEditor1.getCursorBufferPosition(), hostEditor1.getCursorBufferPosition()))
-    hostEditor1.setCursorBufferPosition([1, 20])
-    await condition(() => deepEqual(guestEditor1.getCursorBufferPosition(), hostEditor1.getCursorBufferPosition()))
+    // hostEnv.workspace.getActivePane().activateItem(hostEditor1)
+    // await getNextActiveTextEditorPromise(guestEnv)
+    // await condition(() => deepEqual(guestEditor1.getCursorBufferPosition(), hostEditor1.getCursorBufferPosition()))
+    // hostEditor1.setCursorBufferPosition([1, 20])
+    // await condition(() => deepEqual(guestEditor1.getCursorBufferPosition(), hostEditor1.getCursorBufferPosition()))
   })
 
   test('adding and removing workspace element classes when sharing a portal', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -890,7 +890,7 @@ suite('TeletypePackage', function () {
       await condition(() => followerEditors[0].lineTextForBufferRow(1).includes('Y'))
       assert(followerEditors[0].getCursorBufferPosition().isEqual([20, 29]))
 
-      // Retract follower's tether and ensure following across tabs still works.
+      // When re-following, ensure that you are taken to the leader's current tab.
       leaderEnv.workspace.paneForItem(leaderEditors[1]).activateItem(leaderEditors[1])
       followerPortal.follow(leaderPortal.siteId)
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -769,7 +769,7 @@ suite('TeletypePackage', function () {
       })
     })
 
-    test.skip('host following guest', async () => {
+    test('host following guest', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
       const guestEnv = buildAtomEnvironment()

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -909,12 +909,21 @@ suite('TeletypePackage', function () {
       // Retract follower's tether and ensure it gets disconnected after switching to a different tab.
       followerPortal.follow(leaderPortal.siteId)
       await condition(() => deepEqual(followerEditors[1].getCursorBufferPosition(), leaderEditors[1].getCursorBufferPosition()))
+
       followerEnv.workspace.getActivePane().activateItem(followerEditors[0])
       await timeout(followerPortal.tetherDisconnectWindow)
+
+      followerEditors[0].setCursorBufferPosition([3, 4])
       leaderEditors[1].setCursorBufferPosition([8, 2])
       leaderEditors[1].insertText('X')
+
       await condition(() => followerEditors[1].lineTextForBufferRow(8).includes('X'))
-      assert(!followerEditors[1].getCursorBufferPosition().isEqual(leaderEditors[1].getCursorBufferPosition()))
+
+      assert.equal(followerEnv.workspace.getActivePaneItem(), followerEditors[0])
+      assert(getCursorDecoratedRanges(followerEditors[0]).find((r) => r.isEqual([[3, 4], [3, 4]])))
+
+      assert.equal(leaderEnv.workspace.getActivePaneItem(), leaderEditors[1])
+      assert(getCursorDecoratedRanges(leaderEditors[1]).find((r) => r.isEqual([[8, 3], [8, 3]])))
     }
   })
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -122,7 +122,7 @@ suite('TeletypePackage', function () {
     assert.equal(getPaneItems(guestEnv).length, 1)
 
     const hostEditor2 = await hostEnv.workspace.open()
-    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
+    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv) // eslint-disable-line no-unused-vars
     assert.equal(getPaneItems(guestEnv).length, 2)
 
     hostEnv.workspace.paneForItem(hostEditor1).activateItem(hostEditor1)
@@ -212,7 +212,7 @@ suite('TeletypePackage', function () {
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // When Portal 2 host shares another local buffer, Portal 2 guests see that buffer
-    const guestAndHostLocalEditor2 = await guestAndHostEnv.workspace.open(path.join(temp.path(), 'host+guest-buffer-2'))
+    await guestAndHostEnv.workspace.open(path.join(temp.path(), 'host+guest-buffer-2'))
     const guestOnlyRemotePaneItem2 = await getNextRemotePaneItemPromise(guestOnlyEnv)
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1, guestOnlyRemotePaneItem2])
   })

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -678,85 +678,88 @@ suite('TeletypePackage', function () {
     }
   })
 
-  test('splitting editors', async () => {
-    const hostEnv = buildAtomEnvironment()
-    const hostPackage = await buildPackage(hostEnv)
-    const portal = await hostPackage.sharePortal()
+  suite('host splitting editors', async () => {
+    test('supporting distinct selections per editor with a shared undo stack for the buffer', async () => {
+      const hostEnv = buildAtomEnvironment()
+      const hostPackage = await buildPackage(hostEnv)
+      const portal = await hostPackage.sharePortal()
 
-    const guestEnv = buildAtomEnvironment()
-    const guestPackage = await buildPackage(guestEnv)
-    guestPackage.joinPortal(portal.id)
+      const guestEnv = buildAtomEnvironment()
+      const guestPackage = await buildPackage(guestEnv)
+      guestPackage.joinPortal(portal.id)
 
-    const hostEditor1 = await hostEnv.workspace.open()
-    hostEditor1.setText('hello = "world"')
-    hostEditor1.setCursorBufferPosition([0, 0])
-    hostEditor1.insertText('const ')
+      const hostEditor1 = await hostEnv.workspace.open()
+      hostEditor1.setText('hello = "world"')
+      hostEditor1.setCursorBufferPosition([0, 0])
+      hostEditor1.insertText('const ')
 
-    hostEnv.workspace.paneForItem(hostEditor1).splitRight({copyActiveItem: true})
-    const hostEditor2 = hostEnv.workspace.getActiveTextEditor()
-    hostEditor2.setCursorBufferPosition([0, 8])
+      hostEnv.workspace.paneForItem(hostEditor1).splitRight({copyActiveItem: true})
+      const hostEditor2 = hostEnv.workspace.getActiveTextEditor()
+      hostEditor2.setCursorBufferPosition([0, 8])
 
-    assert.equal(hostEditor2.getBuffer(), hostEditor1.getBuffer())
+      assert.equal(hostEditor2.getBuffer(), hostEditor1.getBuffer())
 
-    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
-    guestEditor2.setCursorBufferPosition([0, Infinity])
-    guestEditor2.insertText('\nconst goodbye = "moon"')
-    await editorsEqual(guestEditor2, hostEditor2)
-    await timeout(guestPackage.tetherDisconnectWindow)
+      const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
+      guestEditor2.setCursorBufferPosition([0, Infinity])
+      guestEditor2.insertText('\nconst goodbye = "moon"')
+      await editorsEqual(guestEditor2, hostEditor2)
+      await timeout(guestPackage.tetherDisconnectWindow)
 
-    hostEditor2.undo()
-    assert.equal(hostEditor2.getText(), 'hello = "world"\nconst goodbye = "moon"')
-    assert.equal(hostEditor1.getText(), hostEditor2.getText())
-    await editorsEqual(hostEditor2, guestEditor2)
+      hostEditor2.undo()
+      assert.equal(hostEditor2.getText(), 'hello = "world"\nconst goodbye = "moon"')
+      assert.equal(hostEditor1.getText(), hostEditor2.getText())
+      await editorsEqual(hostEditor2, guestEditor2)
 
-    hostEnv.workspace.paneForItem(hostEditor1).activate()
-    const guestEditor1 = await getNextActiveTextEditorPromise(guestEnv)
-    assert.equal(guestEditor1.getBuffer(), guestEditor2.getBuffer())
-    await editorsEqual(guestEditor1, hostEditor1)
+      hostEnv.workspace.paneForItem(hostEditor1).activate()
+      const guestEditor1 = await getNextActiveTextEditorPromise(guestEnv)
+      assert.equal(guestEditor1.getBuffer(), guestEditor2.getBuffer())
+      await editorsEqual(guestEditor1, hostEditor1)
 
-    guestEditor1.undo()
-    assert.equal(guestEditor1.getText(), 'hello = "world"')
-    assert.equal(guestEditor2.getText(), guestEditor1.getText())
-    await editorsEqual(guestEditor1, hostEditor1)
-  })
+      guestEditor1.undo()
+      assert.equal(guestEditor1.getText(), 'hello = "world"')
+      assert.equal(guestEditor2.getText(), guestEditor1.getText())
+      await editorsEqual(guestEditor1, hostEditor1)
+    })
 
-  test('remotifying and deremotifying guest editors and buffers when host splits an editor', async () => {
-    const hostEnv = buildAtomEnvironment()
-    const hostPackage = await buildPackage(hostEnv)
-    const portal = await hostPackage.sharePortal()
-    const guestEnv = buildAtomEnvironment()
-    const guestPackage = await buildPackage(guestEnv)
-    guestPackage.joinPortal(portal.id)
+    test('remotifying and deremotifying guest editors and buffers', async () => {
+      const hostEnv = buildAtomEnvironment()
+      const hostPackage = await buildPackage(hostEnv)
+      const portal = await hostPackage.sharePortal()
 
-    const hostEditor1 = await hostEnv.workspace.open(path.join(temp.path(), 'a.txt'))
-    const guestEditor1 = await getNextActiveTextEditorPromise(guestEnv)
+      const guestEnv = buildAtomEnvironment()
+      const guestPackage = await buildPackage(guestEnv)
+      guestPackage.joinPortal(portal.id)
 
-    hostEnv.workspace.paneForItem(hostEditor1).splitRight({copyActiveItem: true})
-    const hostEditor2 = hostEnv.workspace.getActiveTextEditor()
-    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
+      const hostEditor1 = await hostEnv.workspace.open(path.join(temp.path(), 'a.txt'))
+      const guestEditor1 = await getNextActiveTextEditorPromise(guestEnv)
 
-    assert.deepEqual(getPaneItems(guestEnv), [guestEditor1, guestEditor2])
-    assert(guestEditor1.isRemote)
-    assert(guestEditor1.getTitle().endsWith('a.txt'))
-    assert(guestEditor1.getBuffer().getPath().endsWith('a.txt'))
-    assert(guestEditor2.isRemote)
-    assert(guestEditor2.getTitle().endsWith('a.txt'))
-    assert(guestEditor2.getBuffer().getPath().endsWith('a.txt'))
+      hostEnv.workspace.paneForItem(hostEditor1).splitRight({copyActiveItem: true})
+      const hostEditor2 = hostEnv.workspace.getActiveTextEditor()
+      const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
 
-    hostEditor2.destroy()
-    await condition(() => deepEqual(getPaneItems(guestEnv), [guestEditor1]))
+      assert.deepEqual(getPaneItems(guestEnv), [guestEditor1, guestEditor2])
+      assert(guestEditor1.isRemote)
+      assert(guestEditor1.getTitle().endsWith('a.txt'))
+      assert(guestEditor1.getBuffer().getPath().endsWith('a.txt'))
+      assert(guestEditor2.isRemote)
+      assert(guestEditor2.getTitle().endsWith('a.txt'))
+      assert(guestEditor2.getBuffer().getPath().endsWith('a.txt'))
 
-    assert(guestEditor1.isRemote)
-    assert(guestEditor1.getTitle().endsWith('a.txt'))
-    assert(guestEditor1.getBuffer().getPath().endsWith('a.txt'))
+      hostEditor2.destroy()
+      await condition(() => deepEqual(getPaneItems(guestEnv), [guestEditor1]))
 
-    hostPackage.closeHostPortal()
+      assert(guestEditor1.isRemote)
+      assert(guestEditor1.getTitle().endsWith('a.txt'))
+      assert(guestEditor1.getBuffer().getPath().endsWith('a.txt'))
 
-    await condition(() =>
-      !guestEditor1.isRemote &&
-      guestEditor1.getTitle() === 'untitled' &&
-      guestEditor1.getBuffer().getPath() === undefined
-    )
+      hostPackage.closeHostPortal()
+
+      await condition(() =>
+        !guestEditor1.isRemote &&
+        guestEditor1.getTitle() === 'untitled' &&
+        guestEditor1.getBuffer().getPath() === undefined
+      )
+    })
   })
 
   test('propagating nested marker layer updates that depend on text updates in a nested transaction', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -200,7 +200,7 @@ suite('TeletypePackage', function () {
     // Portal 2 host continues to exist as a guest in Portal 1
     hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-2'))
     const guestAndHostRemotePaneItem2 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
+    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem2, guestAndHostLocalEditor1])
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // No transitivity: When Portal 2 host is viewing contents of Portal 1, Portal 2 guests can only see contents of Portal 2
@@ -212,7 +212,7 @@ suite('TeletypePackage', function () {
     // As Portal 2 host observes changes in Portal 1, Portal 2 guests continue to only see contents of Portal 2
     await hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-3'))
     const guestAndHostRemotePaneItem3 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
+    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem2, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1])
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // When Portal 2 host shares another local buffer, Portal 2 guests see that buffer

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -3,6 +3,7 @@ const {Errors} = require('@atom/teletype-client')
 const {TextBuffer, TextEditor} = require('atom')
 
 const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
+const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
 const assert = require('assert')
 const condition = require('./helpers/condition')
 const deepEqual = require('deep-equal')
@@ -830,6 +831,7 @@ suite('TeletypePackage', function () {
 
     async function verifyTetheringRules ({leaderEnv, leaderPortal, followerEnv, followerPortal}) {
       // Setup DOM for follower's workspace.
+      loadPackageStyleSheets(followerEnv)
       const followerWorkspaceElement = followerEnv.views.getView(followerEnv.workspace)
       followerWorkspaceElement.style.height = '100px'
       followerWorkspaceElement.style.width = '250px'

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -198,11 +198,7 @@ suite('TeletypePackage', function () {
     // Portal 2 host continues to exist as a guest in Portal 1
     hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-2'))
     const guestAndHostRemotePaneItem2 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    // TODO Remove sorting. Order should be guaranteed.
-    assert.deepEqual(
-      getPaneItems(guestAndHostEnv).sort((a, b) => a.id - b.id),
-      [guestAndHostRemotePaneItem1, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2].sort((a, b) => a.id - b.id)
-    )
+    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // No transitivity: When Portal 2 host is viewing contents of Portal 1, Portal 2 guests can only see contents of Portal 2
@@ -213,11 +209,7 @@ suite('TeletypePackage', function () {
     // As Portal 2 host observes changes in Portal 1, Portal 2 guests continue to only see contents of Portal 2
     await hostOnlyEnv.workspace.open(path.join(temp.path(), 'host-only-buffer-3'))
     const guestAndHostRemotePaneItem3 = await getNextRemotePaneItemPromise(guestAndHostEnv)
-    // TODO Remove sorting. Order should be guaranteed.
-    assert.deepEqual(
-      getPaneItems(guestAndHostEnv).sort((a, b) => a.id - b.id),
-      [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2].sort((a, b) => a.id - b.id)
-    )
+    assert.deepEqual(getPaneItems(guestAndHostEnv), [guestAndHostRemotePaneItem1, guestAndHostRemotePaneItem3, guestAndHostLocalEditor1, guestAndHostRemotePaneItem2])
     assert.deepEqual(getPaneItems(guestOnlyEnv), [guestOnlyRemotePaneItem1])
 
     // When Portal 2 host shares another local buffer, Portal 2 guests see that buffer


### PR DESCRIPTION
### Demo

![demo](https://user-images.githubusercontent.com/2988/33579126-b2070d38-d916-11e7-92f9-bf67a3b73db5.gif)

### Description of the Change

This pull request implements the core parts of the functionality described in [RFC-001](https://github.com/atom/teletype/blob/1380adb2725f3c70b27e096d84cd9af7bd2819be/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md):

> If you continue to follow the host [after first joining the portal], any time they switch to a new buffer, a new editor for that remote buffer is automatically added to your workspace and focused. Existing editors for previous remote buffers are not automatically closed when this switch occurs.
>
> When a host closes a buffer, it will be removed from all guest portals. ...
>
> You can follow any other guest participating in the host's workspace in the exact same way. If they move between buffers, you will follow them.

#### Coming in future pull requests

The following features of RFC-001 will be addressed in future pull requests:

- Enhance the fuzzy finder to allow guests to navigate to any buffer that the host currently has open in their workspace.
- If a guest is working in a buffer when the host attempts to close the buffer, before removing the buffer from the portal, ask the host to confirm their intention to remove the buffer.

### Alternate Designs

See [RFC-001](https://github.com/atom/teletype/blob/1380adb2725f3c70b27e096d84cd9af7bd2819be/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md#rationale-and-alternatives)

### Benefits

See [RFC-001](https://github.com/atom/teletype/blob/1380adb2725f3c70b27e096d84cd9af7bd2819be/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md#motivation)

### Possible Drawbacks

See [RFC-001](https://github.com/atom/teletype/blob/1380adb2725f3c70b27e096d84cd9af7bd2819be/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md#drawbacks)

### Verification Process

- [x] Multiple guests can join portal
- [x] Guest can edit host's active buffer
- [x] Guest can edit inactive buffer shared by host
- [x] Guest sees empty portal pane item when host closes all active editors
- [x] Host closing portal changes guest's remote editors to untitled, unsaved local editors
- [x] Guest leaving portal removes the portal's editors from guest's workspace

### Applicable Issues

https://github.com/atom/teletype/pull/231: Introduced RFC-001.
https://github.com/atom/teletype/issues/211: Requests sharing entire project. This pull request doesn't allow you to automatically share an entire project/folder, but we anticipate that this will be a useful interim improvement for many people that are interested in sharing a whole project.

### TODO

- [x] Implement [pending test](https://github.com/atom/teletype/blob/1380adb2725f3c70b27e096d84cd9af7bd2819be/test/host-portal-binding.test.js#L60-L62)
- [x] Improve positioning of avatars to avoid covering file tabs
- [x] Exploratory testing, including but not limited to:
  - [x] Handling of split panes on host and guests
  - [x] Following, unfollowing, and re-following a participant
  - [x] New guest joining after multiple editors have already been shared with existing guests
  - [x] Host removing editors from the portal
  - [x] Positioning of avatars in popular UI themes
- [x] Fix bug where host splits panes and then closes one pane item and then guest sees "untitled" for all tabs (https://github.com/atom/teletype/pull/262#issuecomment-349774145)
- [x] When host goes from *n* editors to zero, all guests start following the host (https://github.com/atom/teletype/pull/262#issuecomment-349774145)
- [x] Fix "Error: Adding a pane item with URI '' that has already been destroyed" (https://github.com/atom/teletype/pull/262#issuecomment-349774145)
- [x] Until we have the fuzzy finder in place for remote editors, when guest closes last remote editor, guest leaves portals
- [x] Bump dependency on atom/teletype-client
    - [x] Open pull request (https://github.com/atom/teletype-client/pull/44)
    - [x] Merge that pull request
    - [x] Publish new version of teletype-client to npm
    - [x] Update `package.json` to depend on new version of teletype-client

---

🍐'ed with @as-cii