### PR TITLE
Save buffer on the host when attempting to save it on the guest

### DIFF
--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -1,4 +1,4 @@
-const {Range} = require('atom')
+const {Range, TextBuffer} = require('atom')
 
 function doNothing () {}
 
@@ -6,6 +6,7 @@ module.exports =
 class BufferBinding {
   constructor ({buffer, isHost, didDispose}) {
     this.buffer = buffer
+    this.saveBuffer = TextBuffer.prototype.save.bind(buffer)
     this.isHost = isHost
     this.emitDidDispose = didDispose || doNothing
     this.pendingChanges = []
@@ -121,6 +122,10 @@ class BufferBinding {
   }
 
   enforceUndoStackSizeLimit () {}
+
+  save () {
+    if (this.buffer.getPath()) return this.saveBuffer()
+  }
 
   serialize (options) {
     return this.serializeUsingDefaultHistoryProviderFormat(options)

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -76,7 +76,7 @@ class EditorBinding {
     let remoteEditorCountForBuffer = buffer.remoteEditorCount || 0
     buffer.remoteEditorCount = ++remoteEditorCountForBuffer
     buffer.getPath = () => `${uriPrefix}:${bufferURI}`
-    buffer.save = () => {}
+    buffer.save = () => { bufferProxy.requestSave() }
     buffer.isModified = () => false
 
     editor.element.classList.add('teletype-RemotePaneItem')

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -340,6 +340,10 @@ suite('EditorBinding', function () {
       assert(editor.element.classList.contains('teletype-RemotePaneItem'))
       assert(!editor.getBuffer().isModified())
 
+      editor.save()
+      editor.save()
+      assert.equal(editorProxy.bufferProxy.saveRequestCount, 2)
+
       binding.dispose()
       assert.equal(editor.getTitle(), 'untitled')
       assert.equal(editor.getURI(), null)
@@ -470,7 +474,13 @@ suite('EditorBinding', function () {
 class FakeEditorProxy {
   constructor (delegate, {siteId} = {}) {
     this.delegate = delegate
-    this.bufferProxy = {uri: 'fake-buffer-proxy-uri'}
+    this.bufferProxy = {
+      uri: 'fake-buffer-proxy-uri',
+      saveRequestCount: 0,
+      requestSave () {
+        this.saveRequestCount++
+      }
+    }
     this.selections = {}
     this.siteId = (siteId == null) ? 1 : siteId
     this.disposed = false


### PR DESCRIPTION
Closes https://github.com/atom/teletype/issues/240

This pull request uses the APIs introduced in https://github.com/atom/teletype-client/pull/45 to:

* Perform a save request when attempting to save a remote buffer on the guest (e5aa4c0).
* Honor the save request on the host by flushing changes to disk. Requests to save in-memory buffers are ignored by the host. (0edbe49)

### Verification

* Open a new Atom instance and share a portal.
* Open a new Atom instance and join the previously shared portal.
* Edit the buffer on the guest portal and save.
* Observe saves being relayed to the host buffer.

/cc: @nathansobo @jasonrudolph 