### PR TITLE
Show updates panel when there is a breaking protocol change

### DIFF
--- a/lib/package-outdated-component.js
+++ b/lib/package-outdated-component.js
@@ -23,12 +23,12 @@ class PackageOutdatedComponent {
           className: 'btn btn-primary btn-sm',
           onClick: this.viewPackageSettings
         },
-        'View Package Settings'
+        'Check Package Updates'
       )
     )
   }
 
   viewPackageSettings () {
-    return this.props.workspace.open('atom://config/packages/teletype')
+    return this.props.workspace.open('atom://config/updates')
   }
 }

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -1034,7 +1034,7 @@ suite('TeletypePackage', function () {
     const openedURIs = []
     env.workspace.open = (uri) => openedURIs.push(uri)
     packageOutdatedComponent.refs.viewPackageSettingsButton.click()
-    assert.deepEqual(openedURIs, ['atom://config/packages/teletype'])
+    assert.deepEqual(openedURIs, ['atom://config/updates'])
   })
 
   test('reports errors attempting to initialize the client', async () => {


### PR DESCRIPTION
Closes #269 

This pull request redirects the user to the Settings View update panel instead of showing the package's settings page. The previous behavior was confusing and not very useful as pointed out in the linked issue.

![package-outdated](https://user-images.githubusercontent.com/482957/33893558-fc0b84f4-df5b-11e7-9006-926946be1765.gif)

@jasonrudolph @ungb: what do you think?