### PR TITLE
Remove duplicate logic for calculating remote prefix

### DIFF
--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -5,11 +5,11 @@ function doNothing () {}
 
 module.exports =
 class BufferBinding {
-  constructor ({buffer, portal, isHost, didDispose}) {
+  constructor ({buffer, isHost, remotePathPrefix, didDispose}) {
     this.buffer = buffer
-    this.portal = portal
     this.saveBuffer = TextBuffer.prototype.save.bind(buffer)
     this.isHost = isHost
+    this.remotePathPrefix = remotePathPrefix
     this.emitDidDispose = didDispose || doNothing
     this.pendingChanges = []
     this.disposed = false
@@ -45,11 +45,9 @@ class BufferBinding {
   }
 
   monkeyPatchBufferMethods () {
-    const hostIdentity = this.portal.getSiteIdentity(1)
-    const uriPrefix = hostIdentity ? `@${hostIdentity.login}` : 'remote'
     const bufferURI = normalizeURI(this.bufferProxy.uri)
     this.buffer.isModified = () => false
-    this.buffer.getPath = () => `${uriPrefix}:${bufferURI}`
+    this.buffer.getPath = () => `${this.remotePathPrefix}:${bufferURI}`
     this.buffer.save = () => { this.bufferProxy.requestSave() }
   }
 

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -7,10 +7,10 @@ const {FollowState} = require('@atom/teletype-client')
 
 module.exports =
 class EditorBinding {
-  constructor ({editor, portal, isHost}) {
+  constructor ({editor, isHost, remoteTitlePrefix}) {
     this.editor = editor
-    this.portal = portal
     this.isHost = isHost
+    this.remoteTitlePrefix = remoteTitlePrefix
     this.emitter = new Emitter()
     this.selectionsMarkerLayer = this.editor.selectionsMarkerLayer.bufferMarkerLayer
     this.markerLayersBySiteId = new Map()
@@ -62,11 +62,9 @@ class EditorBinding {
 
   monkeyPatchEditorMethods (editor, editorProxy) {
     const {bufferProxy} = editorProxy
-    const hostIdentity = this.portal.getSiteIdentity(1)
-    const uriPrefix = hostIdentity ? `@${hostIdentity.login}` : 'remote'
 
     const bufferURI = normalizeURI(bufferProxy.uri)
-    editor.getTitle = () => `${uriPrefix}: ${path.basename(bufferURI)}`
+    editor.getTitle = () => `${this.remoteTitlePrefix}: ${path.basename(bufferURI)}`
     editor.getURI = () => ''
     editor.copy = () => null
     editor.serialize = () => null

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -136,8 +136,8 @@ class GuestPortalBinding {
       editor = new TextEditor({buffer, autoHeight: false})
       editorBinding = new EditorBinding({
         editor,
-        portal: this.portal,
-        isHost: false
+        isHost: false,
+        remoteTitlePrefix: safeRemotePrefixFrom(this.portal.getSiteIdentity(1))
       })
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
@@ -164,8 +164,8 @@ class GuestPortalBinding {
       buffer = new TextBuffer()
       bufferBinding = new BufferBinding({
         buffer,
-        portal: this.portal,
         isHost: false,
+        remotePathPrefix: safeRemotePrefixFrom(this.portal.getSiteIdentity(1)),
         didDispose: () => this.bufferBindingsByBufferProxy.delete(bufferProxy)
       })
       bufferBinding.setBufferProxy(bufferProxy)
@@ -292,4 +292,8 @@ class GuestPortalBinding {
   onDidChange (callback) {
     return this.emitter.on('did-change', callback)
   }
+}
+
+function safeRemotePrefixFrom (identity) {
+  return identity ? `@${identity.login}` : 'remote'
 }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -122,7 +122,7 @@ class HostPortalBinding {
     } else {
       const bufferProxy = this.findOrCreateBufferProxyForBuffer(editor.getBuffer())
       const editorProxy = this.portal.createEditorProxy({bufferProxy})
-      editorBinding = new EditorBinding({editor, portal: this.portal, isHost: true})
+      editorBinding = new EditorBinding({editor, isHost: true})
       editorBinding.setEditorProxy(editorProxy)
       editorProxy.setDelegate(editorBinding)
 

--- a/test/buffer-binding.test.js
+++ b/test/buffer-binding.test.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 const fs = require('fs')
 const temp = require('temp')
 const {TextBuffer, Point} = require('atom')
-const FakePortal = require('./helpers/fake-portal')
 const BufferBinding = require('../lib/buffer-binding')
 
 suite('BufferBinding', function () {
@@ -10,7 +9,7 @@ suite('BufferBinding', function () {
 
   test('relays changes to and from the shared buffer', () => {
     const buffer = new TextBuffer('hello\nworld')
-    const binding = new BufferBinding({buffer, portal: new FakePortal()})
+    const binding = new BufferBinding({buffer})
     const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
     binding.setBufferProxy(bufferProxy)
 
@@ -36,7 +35,7 @@ suite('BufferBinding', function () {
 
   test('does not relay empty changes to the shared buffer', () => {
     const buffer = new TextBuffer('hello\nworld')
-    const binding = new BufferBinding({buffer, portal: new FakePortal()})
+    const binding = new BufferBinding({buffer})
     const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
     binding.setBufferProxy(bufferProxy)
 
@@ -48,7 +47,7 @@ suite('BufferBinding', function () {
   suite('host buffer binding', async () => {
     test('flushes changes to disk when receiving a save request', async () => {
       const buffer = new TextBuffer('hello\nworld')
-      const binding = new BufferBinding({buffer, isHost: true, portal: new FakePortal()})
+      const binding = new BufferBinding({buffer, isHost: true})
       const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
       binding.setBufferProxy(bufferProxy)
 
@@ -72,7 +71,7 @@ suite('BufferBinding', function () {
   suite('guest buffer binding', () => {
     test('overrides the buffer methods when setting the proxy, and restores them on dispose', () => {
       const buffer = new TextBuffer('abc')
-      const binding = new BufferBinding({buffer, isHost: false, portal: new FakePortal()})
+      const binding = new BufferBinding({buffer, isHost: false, remotePathPrefix: '@site-1'})
       const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
 
       binding.setBufferProxy(bufferProxy)
@@ -92,7 +91,7 @@ suite('BufferBinding', function () {
   suite('destroying the buffer', () => {
     test('on the host, disposes the underlying buffer proxy', () => {
       const buffer = new TextBuffer('')
-      const binding = new BufferBinding({buffer, isHost: true, portal: new FakePortal()})
+      const binding = new BufferBinding({buffer, isHost: true})
       const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
       binding.setBufferProxy(bufferProxy)
 
@@ -102,7 +101,7 @@ suite('BufferBinding', function () {
 
     test('on guests, disposes the buffer binding', () => {
       const buffer = new TextBuffer('')
-      const binding = new BufferBinding({buffer, isHost: false, portal: new FakePortal()})
+      const binding = new BufferBinding({buffer, isHost: false})
       const bufferProxy = new FakeBufferProxy(binding, buffer.getText())
       binding.setBufferProxy(bufferProxy)
 

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -53,7 +53,7 @@ suite('EditorBinding', function () {
     editor.setText(SAMPLE_TEXT)
     editor.setCursorBufferPosition([0, 0])
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
     assert.deepEqual(
@@ -122,7 +122,7 @@ suite('EditorBinding', function () {
     editor.setText(SAMPLE_TEXT)
     editor.setCursorBufferPosition([0, 0])
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -157,7 +157,7 @@ suite('EditorBinding', function () {
     editor.setText(SAMPLE_TEXT)
     editor.setCursorBufferPosition([0, 0])
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -197,7 +197,7 @@ suite('EditorBinding', function () {
     editor.setText(SAMPLE_TEXT)
     editor.setSelectedBufferRange([[0, 0], [0, 3]])
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
     binding.updateSelectionsForSiteId(2, {
@@ -237,7 +237,7 @@ suite('EditorBinding', function () {
     editor.setText(SAMPLE_TEXT)
     editor.setCursorBufferPosition([0, 0])
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -279,7 +279,7 @@ suite('EditorBinding', function () {
     const editor = new TextEditor()
     editor.setText(SAMPLE_TEXT)
 
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -304,7 +304,7 @@ suite('EditorBinding', function () {
   suite('destroying the editor', () => {
     test('on the host, disposes the underlying editor proxy', () => {
       const editor = new TextEditor()
-      const binding = new EditorBinding({editor, isHost: true, portal: new FakePortal()})
+      const binding = new EditorBinding({editor, isHost: true})
       const editorProxy = new FakeEditorProxy(binding)
       binding.setEditorProxy(editorProxy)
 
@@ -314,7 +314,7 @@ suite('EditorBinding', function () {
 
     test('on guests, disposes the editor binding', () => {
       const editor = new TextEditor()
-      const binding = new EditorBinding({editor, isHost: false, portal: new FakePortal()})
+      const binding = new EditorBinding({editor, isHost: false})
       const editorProxy = new FakeEditorProxy(binding)
       binding.setEditorProxy(editorProxy)
 
@@ -329,7 +329,7 @@ suite('EditorBinding', function () {
       const buffer = new TextBuffer({text: SAMPLE_TEXT})
       const editor = new TextEditor({buffer})
 
-      const binding = new EditorBinding({editor, portal: new FakePortal(), isHost: false})
+      const binding = new EditorBinding({editor, remoteTitlePrefix: '@site-1', isHost: false})
       const editorProxy = new FakeEditorProxy(binding)
       binding.setEditorProxy(editorProxy)
       assert.equal(editor.getTitle(), '@site-1: fake-buffer-proxy-uri')
@@ -350,7 +350,7 @@ suite('EditorBinding', function () {
   test('decorates each cursor with a site-specific class name', () => {
     const editor = new TextEditor()
     editor.setText(SAMPLE_TEXT)
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding, {siteId: 2})
 
     binding.setEditorProxy(editorProxy)
@@ -371,7 +371,7 @@ suite('EditorBinding', function () {
 
   test('isScrollNeededToViewPosition(position)', async () => {
     const editor = new TextEditor({autoHeight: false})
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -403,7 +403,7 @@ suite('EditorBinding', function () {
   test('destroys folds intersecting the position of the leader', async () => {
     const buffer = new TextBuffer({text: SAMPLE_TEXT})
     const editor = new TextEditor({buffer})
-    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const binding = new EditorBinding({editor})
     const editorProxy = new FakeEditorProxy(binding)
     binding.setEditorProxy(editorProxy)
 
@@ -487,11 +487,5 @@ class FakeEditorProxy {
         delete this.selections[id]
       }
     }
-  }
-}
-
-class FakePortal {
-  getSiteIdentity (siteId) {
-    return {login: 'site-' + siteId}
   }
 }

--- a/test/site-positions-controller.test.js
+++ b/test/site-positions-controller.test.js
@@ -59,13 +59,13 @@ suite('SitePositionsController', () => {
 
     const editorProxy1 = new FakeEditorProxy()
     const editor1 = new TextEditor({autoHeight: false, buffer: new TextBuffer(SAMPLE_TEXT)})
-    const editorBinding1 = new EditorBinding({portal, editor: editor1})
+    const editorBinding1 = new EditorBinding({editor: editor1})
     editorBinding1.setEditorProxy(editorProxy1)
     controller.addEditorBinding(editorBinding1)
 
     const editorProxy2 = new FakeEditorProxy()
     const editor2 = new TextEditor({autoHeight: false, buffer: new TextBuffer(SAMPLE_TEXT)})
-    const editorBinding2 = new EditorBinding({portal, editor: editor2})
+    const editorBinding2 = new EditorBinding({editor: editor2})
     editorBinding2.setEditorProxy(editorProxy2)
     controller.addEditorBinding(editorBinding2)
 


### PR DESCRIPTION
In #270, 3a30144db33bf2858f347a4e112e59228cc030e6 duplicates the logic for determining the prefix for a remote title/path.

https://github.com/atom/teletype/blob/3a30144db33bf2858f347a4e112e59228cc030e6/lib/buffer-binding.js#L48-L49

https://github.com/atom/teletype/blob/3a30144db33bf2858f347a4e112e59228cc030e6/lib/editor-binding.js#L65-L66

This pull request proposes a refactoring that eliminates that duplication and removes the dependency on `Portal` in `EditorBinding` and `BufferBinding`.

@as-cii: What do you think?

