### PR TITLE
Close/leave portals when deactivating TeletypePackage

### DIFF
--- a/lib/portal-binding-manager.js
+++ b/lib/portal-binding-manager.js
@@ -18,14 +18,14 @@ class PortalBindingManager {
 
     if (this.hostPortalBindingPromise) {
       const disposePromise = this.hostPortalBindingPromise.then((portalBinding) => {
-        portalBinding.dispose()
+        portalBinding.close()
       })
       disposePromises.push(disposePromise)
     }
 
     this.promisesByGuestPortalId.forEach(async (portalBindingPromise) => {
       const disposePromise = portalBindingPromise.then((portalBinding) => {
-        if (portalBinding) portalBinding.dispose()
+        if (portalBinding) portalBinding.leave()
       })
       disposePromises.push(disposePromise)
     })


### PR DESCRIPTION
Previously, deactivating the TeletypePackage would only dispose the bindings without tearing down the associated portal instances. This would cause the disposed bindings to keep receiving messages from e.g. Portal or EditorProxy and would throw errors because the binding methods were called while being in a inconsistent/disposed state.

This pull request addresses the exceptions we were observing in the DevTools when running tests locally by closing/leaving all the portals managed by PortalBindingManager when tearing down the package.

/cc: @jasonrudolph 