### PR TITLE
Show site position avatars inside remote pane items

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -29,13 +29,12 @@ class GuestPortalBinding {
       if (!this.portal) return false
 
       this.sitePositionsController = new SitePositionsController({portal: this.portal, workspace: this.workspace})
-      this.sitePositionsController.show()
+      this.subscriptions.add(this.workspace.onDidChangeActivePaneItem(this.didChangeActivePaneItem.bind(this)))
+      this.subscriptions.add(this.workspace.onDidDestroyPaneItem(this.didDestroyPaneItem.bind(this)))
 
       await this.portal.setDelegate(this)
       await this.toggleEmptyPortalPaneItem()
 
-      this.subscriptions.add(this.workspace.onDidChangeActivePaneItem(this.didChangeActivePaneItem.bind(this)))
-      this.subscriptions.add(this.workspace.onDidDestroyPaneItem(this.didDestroyPaneItem.bind(this)))
       return true
     } catch (error) {
       this.didFailToJoin(error)
@@ -247,7 +246,7 @@ class GuestPortalBinding {
     const editorProxy = this.editorProxiesByEditor.get(paneItem)
 
     if (editorProxy || paneItem === this.getEmptyPortalPaneItem()) {
-      this.sitePositionsController.show()
+      this.sitePositionsController.show(paneItem.element)
     } else {
       this.sitePositionsController.hide()
     }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -75,7 +75,7 @@ class HostPortalBinding {
     if (editor && !editor.isRemote) {
       const editorProxy = this.findOrCreateEditorProxyForEditor(editor)
       this.portal.activateEditorProxy(editorProxy)
-      this.sitePositionsController.show()
+      this.sitePositionsController.show(editor.element)
     } else {
       this.portal.activateEditorProxy(null)
       this.sitePositionsController.hide()

--- a/lib/site-positions-controller.js
+++ b/lib/site-positions-controller.js
@@ -22,8 +22,7 @@ class SitePositionsController {
     this.outsideViewportSitePositionsComponent.destroy()
   }
 
-  show () {
-    const containerElement = this.workspace.getCenter().paneContainer.getElement()
+  show (containerElement) {
     containerElement.appendChild(this.aboveViewportSitePositionsComponent.element)
     containerElement.appendChild(this.insideViewportSitePositionsComponent.element)
     containerElement.appendChild(this.outsideViewportSitePositionsComponent.element)

--- a/test/site-positions-controller.test.js
+++ b/test/site-positions-controller.test.js
@@ -35,17 +35,22 @@ suite('SitePositionsController', () => {
       editorBindingForEditorProxy: () => {}
     })
 
-    const workspaceCenterElement = workspace.getCenter().paneContainer.getElement()
+    const element1 = document.createElement('div')
+    controller.show(element1)
+    assert(element1.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(element1.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(element1.contains(controller.outsideViewportSitePositionsComponent.element))
 
-    controller.show()
-    assert(workspaceCenterElement.contains(controller.aboveViewportSitePositionsComponent.element))
-    assert(workspaceCenterElement.contains(controller.insideViewportSitePositionsComponent.element))
-    assert(workspaceCenterElement.contains(controller.outsideViewportSitePositionsComponent.element))
+    const element2 = document.createElement('div')
+    controller.show(element2)
+    assert(element2.contains(controller.aboveViewportSitePositionsComponent.element))
+    assert(element2.contains(controller.insideViewportSitePositionsComponent.element))
+    assert(element2.contains(controller.outsideViewportSitePositionsComponent.element))
 
     controller.hide()
-    assert(!workspaceCenterElement.contains(controller.aboveViewportSitePositionsComponent.element))
-    assert(!workspaceCenterElement.contains(controller.insideViewportSitePositionsComponent.element))
-    assert(!workspaceCenterElement.contains(controller.outsideViewportSitePositionsComponent.element))
+    assert(!controller.aboveViewportSitePositionsComponent.element.parentElement)
+    assert(!controller.insideViewportSitePositionsComponent.element.parentElement)
+    assert(!controller.outsideViewportSitePositionsComponent.element.parentElement)
   })
 
   test('updateActivePositions(positionsBySiteId)', async () => {


### PR DESCRIPTION
Fixes #276

Previously, we would show site position avatars on the right hand side of the workspace center element. As illustrated in the aforementioned issue, this could cause a confusing behavior when interacting with split panes:

<img width="636" alt="screen shot 2017-12-14 at 11 27 22" src="https://user-images.githubusercontent.com/482957/33987609-cb1e48ba-e0c1-11e7-9d3b-0e0dea620e1c.png">

With this pull request we are moving site position avatars from the "workspace center" element to the currently active remote pane item:

| before  | after   |
|---------|---------|
| ![before](https://user-images.githubusercontent.com/482957/33987517-6ead8668-e0c1-11e7-902a-ce374c63ef61.gif) | ![after](https://user-images.githubusercontent.com/482957/33987519-70c29f6a-e0c1-11e7-9b6c-e1b99bd5ab90.gif) |

### Verification steps

On a portal with one or more guests:

* Create some split items on the host (or, analogously, move remote buffers into other panes on the guest).
* Move among tabs and notice how site position avatars follow the currently active remote pane item.
* Notice also how focusing a non-remote pane item (e.g. git diff view) hides the avatars.

/cc: @jasonrudolph @ungb @rsese 