### PR TITLE
Update RFC-001 to remove extraneous step

### DIFF
--- a/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
+++ b/doc/rfcs/001-allow-guests-to-open-multiple-remote-buffers.md
@@ -28,7 +28,7 @@ When you first join a portal as a guest, you're automatically *following* the ho
 
 In order to jump to the host's current position, an editor is automatically added to your workspace for their active buffer when you first join their workspace. If you continue to follow the host, any time they switch to a new buffer, a new editor for that remote buffer is automatically added to your workspace and focused. Existing editors for previous remote buffers are not automatically closed when this switch occurs.
 
-When a host closes a buffer, it will be removed from all guest portals. If another participant is working in that same buffer (i.e., not following the host), Teletype will first ask the host to confirm their intention to remove the buffer from the portal.
+When a host closes a buffer, it will be removed from all guest portals.
 
 You can follow any other guest participating in the host's workspace in the exact same way. If they move between buffers, you will follow them. The host does not enjoy any special privilege with respect to the ability to be followed between different files.
 


### PR DESCRIPTION
RFC-001 currently includes the following paragraph:

> When a host closes a buffer, it will be removed from all guest portals. If another participant is working in that same buffer (i.e., not following the host), Teletype will first ask the host to confirm their intention to remove the buffer from the portal.

This pull request proposes that we remove the second sentence from that paragraph.

Our motivation for this change is as follows:

- If a host attempts to close a buffer that the guest is editing, Atom will detect that the buffer has unsaved changes, and Atom will automatically prompt the host to confirm their intention to close the buffer. If Teletype *also* attempts to confirm the host's intention to close the buffer, we'll essentially be prompting the host _twice_ before they can close the buffer. 😬
- @as-cii and I have been using the current behavior (implemented in #262) for a few weeks, and we haven't yet encountered a situation where this confirmation would have been useful.
- We may [eventually](https://github.com/atom/teletype/issues/268#issuecomment-350764740) want to allow guests to keep remote buffers open after the host closes them.  If so, this confirmation would no longer be relevant and we'd need to remove it.

---

Refs: https://github.com/atom/teletype/issues/268
