### PR TITLE
Provide "reload" button when displaying initialization error

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const TeletypePackage = require('./lib/teletype-package')
 module.exports = new TeletypePackage({
   workspace: atom.workspace,
   notificationManager: atom.notifications,
+  packageManager: atom.packages,
   commandRegistry: atom.commands,
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,

--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -16,16 +16,16 @@ class PackageInitializationErrorComponent {
   render () {
     return $.div({className: 'PackageInitializationErrorComponent'},
       $.h3(null, 'Teletype initialization failed'),
-      $.p(null, 'Make sure your internet connection is working and reload Atom.'),
+      $.p(null, 'Make sure your internet connection is working and restart the package.'),
       $.div(null,
         $.button(
           {
             ref: 'reloadButton',
             type: 'button',
             className: 'btn btn-primary inline-block-tight',
-            onClick: this.reloadAtom
+            onClick: this.restartTeletype
           },
-          'Reload Atom'
+          'Restart Teletype'
         )
       ),
       $.p(null,
@@ -36,7 +36,9 @@ class PackageInitializationErrorComponent {
     )
   }
 
-  reloadAtom () {
-    location.reload() // eslint-disable-line no-undef
+  async restartTeletype () {
+    const {packageManager} = this.props
+    await packageManager.deactivatePackage('teletype')
+    await packageManager.activatePackage('teletype')
   }
 }

--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -16,12 +16,27 @@ class PackageInitializationErrorComponent {
   render () {
     return $.div({className: 'PackageInitializationErrorComponent'},
       $.h3(null, 'Teletype initialization failed'),
-      $.p(null, 'Make sure your internet connection is working and restart the package.'),
+      $.p(null, 'Make sure your internet connection is working and reload Atom.'),
+      $.div(null,
+        $.button(
+          {
+            ref: 'reloadButton',
+            type: 'button',
+            className: 'btn btn-primary inline-block-tight',
+            onClick: this.reloadAtom
+          },
+          'Reload Atom'
+        )
+      ),
       $.p(null,
         'If the problem persists, visit ',
         $.a({href: 'https://github.com/atom/teletype/issues/new', className: 'text-info'}, 'atom/teletype'),
         ' and open an issue.'
       )
     )
+  }
+
+  reloadAtom () {
+    location.reload() // eslint-disable-line no-undef
   }
 }

--- a/lib/popover-component.js
+++ b/lib/popover-component.js
@@ -23,7 +23,7 @@ class PopoverComponent {
     const {
       isClientOutdated, initializationError,
       authenticationProvider, portalBindingManager,
-      commandRegistry, clipboard, workspace, notificationManager
+      commandRegistry, clipboard, workspace, notificationManager, packageManager
     } = this.props
 
     let activeComponent
@@ -34,7 +34,8 @@ class PopoverComponent {
       })
     } else if (initializationError) {
       activeComponent = $(PackageInitializationErrorComponent, {
-        ref: 'packageInitializationErrorComponent'
+        ref: 'packageInitializationErrorComponent',
+        packageManager
       })
     } else if (this.props.authenticationProvider.isSignedIn()) {
       activeComponent = $(PortalListComponent, {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -9,12 +9,13 @@ module.exports =
 class TeletypePackage {
   constructor (options) {
     const {
-      workspace, notificationManager, commandRegistry, tooltipManager, clipboard,
+      workspace, notificationManager, packageManager, commandRegistry, tooltipManager, clipboard,
       credentialCache, pubSubGateway, pusherKey, pusherOptions, baseURL, tetherDisconnectWindow
     } = options
 
     this.workspace = workspace
     this.notificationManager = notificationManager
+    this.packageManager = packageManager
     this.commandRegistry = commandRegistry
     this.tooltipManager = tooltipManager
     this.clipboard = clipboard
@@ -63,6 +64,8 @@ class TeletypePackage {
   }
 
   async deactivate () {
+    this.initializationError = null
+
     if (this.subscriptions) this.subscriptions.dispose() // Package is not activated in specs
     if (this.portalStatusBarIndicator) this.portalStatusBarIndicator.destroy()
 
@@ -127,7 +130,8 @@ class TeletypePackage {
       commandRegistry: this.commandRegistry,
       clipboard: this.clipboard,
       workspace: this.workspace,
-      notificationManager: this.notificationManager
+      notificationManager: this.notificationManager,
+      packageManager: this.packageManager
     })
 
     this.portalStatusBarIndicator.attach()

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -9,8 +9,9 @@ module.exports =
 class TeletypePackage {
   constructor (options) {
     const {
-      workspace, notificationManager, packageManager, commandRegistry, tooltipManager, clipboard,
-      credentialCache, pubSubGateway, pusherKey, pusherOptions, baseURL, tetherDisconnectWindow
+      baseURL, clipboard, commandRegistry, credentialCache, notificationManager,
+      packageManager, pubSubGateway, pusherKey, pusherOptions,
+      tetherDisconnectWindow, tooltipManager, workspace
     } = options
 
     this.workspace = workspace

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -415,4 +415,8 @@
   color: @text-color;
   text-align: center;
   padding: 0 @component-padding @component-padding @component-padding;
+
+  .btn {
+    margin-bottom: @component-padding * 1.5;
+  }
 }


### PR DESCRIPTION
The initialization errors seen in #250 appear to be transient. https://github.com/atom/teletype/issues/250#issuecomment-348382047 notes:

> On OSX I had `Failed to load resource: net::ERR_NAME_NOT_RESOLVED` but was also unable to check for outdated packages in atom. It may be a DNS race, where it times out before resolving. Loading https://atom.io in a browser and a restart "fixed" it for the time being. Making me think that it's an infrastructure or network error rather than `teletype` specific.

Since "trying again" often Atom seems to resolve the issue, this pull request provides a "Reload Atom" button when the popover component displays an initialization error.

### Demo

![demo](https://user-images.githubusercontent.com/2988/34050871-764d97ea-e18a-11e7-83c7-e1ccab6eba6a.gif)

### Verification Process

1. Disable network access on computer
2. Open Atom window
3. Verify that "Reload Atom" button appears in Teletype popover
4. Enable network access son computer
5. Click "Reload Atom"
6. Click on the portal icon to verify that Teletype initialized successfully

---

This change may be sufficient to close #250. I propose that we roll this out and see if people still run into issues.
