### PR TITLE
Add RFC template

### DIFF
--- a/doc/rfcs/000-template.md
+++ b/doc/rfcs/000-template.md
@@ -1,0 +1,37 @@
+# Feature title
+
+## Status
+
+Proposed
+
+## Summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Explanation
+
+Explain the proposal as if it was already implemented in the Teletype package and you were describing it to an Atom user. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining any changes to existing workflows.
+
+## Drawbacks
+
+Why should we *not* do this?
+
+## Rationale and alternatives
+
+- Why is this approach the best in the space of possible approaches?
+- What other approaches have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+## Unresolved questions
+
+- What unresolved questions do you expect to resolve through the RFC process before this gets merged?
+- What unresolved questions do you expect to resolve through the implementation of this feature before it is released in a new version of the package?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?


### PR DESCRIPTION
Building on the RFC experiment initiated in https://github.com/atom/teletype/pull/231, this pull request adds a template for use in contributing new RFCs.

Much like https://github.com/atom/teletype/pull/231, this pull request borrows heavily from the [approach used by the Rust community](https://github.com/rust-lang/rfcs/blob/b38be1133a36f060208a13d2c0e291a0a7b90d99/0000-template.md).

As we continue the RFC experiment, we'll likely follow up with some documentation in our contribution guide to help community members create RFCs. In the meantime, this template feels useful to add now, so that we can provide a starting point for potential contributors (e.g., https://github.com/atom/teletype/issues/30#issuecomment-348055825 and https://github.com/atom/teletype/issues/281#issuecomment-351549979).