### PR TITLE
Update for compatibility with Atom 1.25

### DIFF
--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -11,6 +11,7 @@ class BufferBinding {
     this.emitDidDispose = didDispose || doNothing
     this.pendingChanges = []
     this.disposed = false
+    this.disableHistory = false
   }
 
   dispose () {
@@ -40,10 +41,15 @@ class BufferBinding {
   }
 
   setText (text) {
+    this.disableHistory = true
+    // TODO: Remove undo skip and require usage latest Atom in engines field when Atom 1.25 reaches stable
     this.buffer.setTextInRange(this.buffer.getRange(), text, {undo: 'skip'})
+    this.disableHistory = false
   }
 
   pushChange (change) {
+    if (this.disableHistory) return
+
     if (this.bufferProxy) {
       const {oldStart, oldEnd, newText} = change
       this.bufferProxy.setTextInRange(oldStart, oldEnd, newText)
@@ -53,6 +59,8 @@ class BufferBinding {
   }
 
   pushChanges (changes) {
+    if (this.disableHistory) return
+
     for (let i = changes.length - 1; i >= 0; i--) {
       this.pushChange(changes[i])
     }
@@ -61,7 +69,10 @@ class BufferBinding {
   updateText (textUpdates) {
     for (let i = textUpdates.length - 1; i >= 0; i--) {
       const {oldStart, oldEnd, newText} = textUpdates[i]
+      this.disableHistory = true
+      // TODO: Remove undo skip and require usage latest Atom in engines field when Atom 1.25 reaches stable
       this.buffer.setTextInRange(new Range(oldStart, oldEnd), newText, {undo: 'skip'})
+      this.disableHistory = false
     }
   }
 
@@ -115,6 +126,10 @@ class BufferBinding {
     } else {
       return false
     }
+  }
+
+  groupLastChanges () {
+    return this.bufferProxy.groupLastChanges()
   }
 
   applyGroupingInterval (groupingInterval) {

--- a/lib/buffer-binding.js
+++ b/lib/buffer-binding.js
@@ -111,14 +111,20 @@ class BufferBinding {
   }
 
   createCheckpoint (options) {
+    if (this.disableHistory) return
+
     return this.bufferProxy.createCheckpoint(options)
   }
 
   groupChangesSinceCheckpoint (checkpoint, options) {
+    if (this.disableHistory) return
+
     return this.bufferProxy.groupChangesSinceCheckpoint(checkpoint, options)
   }
 
   revertToCheckpoint (checkpoint, options) {
+    if (this.disableHistory) return
+
     const result = this.bufferProxy.revertToCheckpoint(checkpoint, options)
     if (result) {
       this.convertMarkerRanges(result.markers)
@@ -129,10 +135,14 @@ class BufferBinding {
   }
 
   groupLastChanges () {
+    if (this.disableHistory) return
+
     return this.bufferProxy.groupLastChanges()
   }
 
   applyGroupingInterval (groupingInterval) {
+    if (this.disableHistory) return
+
     this.bufferProxy.applyGroupingInterval(groupingInterval)
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.31.1",
+    "@atom/teletype-client": "^0.31.2",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.30.2",
+    "@atom/teletype-client": "^0.31.1",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/test/buffer-binding.test.js
+++ b/test/buffer-binding.test.js
@@ -132,6 +132,10 @@ suite('BufferBinding', function () {
       return []
     }
 
+    groupLastChanges () {
+      return true
+    }
+
     applyGroupingInterval () {
 
     }

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -15,7 +15,9 @@ class FakePortal {
       setDelegate () {},
       createCheckpoint () {},
       groupChangesSinceCheckpoint () {},
-      applyGroupingInterval () {}
+      applyGroupingInterval () {},
+      revertToCheckpoint () {},
+      setTextInRange () {}
     }
   }
 

--- a/test/host-portal-binding.test.js
+++ b/test/host-portal-binding.test.js
@@ -83,7 +83,7 @@ suite('HostPortalBinding', () => {
     await portalBinding.initialize()
 
     const editor = await atomEnv.workspace.open()
-    editor.getBuffer().setTextInRange('Lorem ipsum dolor', [[0, 0], [0, 0]], {undo: 'skip'})
+    editor.getBuffer().setTextInRange('Lorem ipsum dolor', [[0, 0], [0, 0]])
     const editorProxy = portal.getActiveEditorProxy()
 
     await portalBinding.updateTether(FollowState.RETRACTED, editorProxy, {row: 0, column: 3})


### PR DESCRIPTION
🍐 d with @as-cii 

Closes #300 

Atom 1.25 introduces two big changes that affect the Teletype package.

1. [x] It upgrades to a version of `text-buffer` containing the changes in https://github.com/atom/text-buffer/pull/282, which changes the behavior `undo: "skip"` option when calling `setTextInRange`. The change is now pushed to the history provider to avoid corruption of the default linear history. In addition, we expect the history provider to implement the `groupLastChanges()` method, which groups the last change with the change before it. This PR updates Teletype to no longer assume `undo: "skip"` does not push the change to the history and implements the new method.

2. [x] We upgrade to Electron 1.17. This seems to introduce some changes in the underlying WebRTC implementation that are causing our tests to fail, though the package seems to work in practice. We need to figure this out or our tests will start failing in February.

![screen shot 2018-01-09 at 10 18 19 am](https://user-images.githubusercontent.com/1789/34733677-72b4105a-f526-11e7-8e9b-01e02510a12c.png)

/cc @jasonrudolph 