### PR TITLE
Use atom/ci's recommended commands for fetching & running the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ addons:
 before_script:
   - createdb teletype-test
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 git:
   depth: 10


### PR DESCRIPTION
In https://github.com/atom/teletype/pull/302#discussion_r161645497, @Arcanemagus suggested an improvement to the `script` section in `.travis.yml`:

> Note that piping a script like this can lead to issues if the connection gets killed in the middle of the script executing and it can be _very_ hard to diagnose as the script output gets quite garbled. That's why `atom/ci` recommends [this way](https://github.com/atom/ci/blob/83744c0308ea7188ff90bd719a86b9dc0fb1d0d0/.travis.yml#L18-L21).

This pull request adopts `atom/ci`'s recommended approach.

---

@Arcanemagus: Thanks for the tip! ⚡️ 