### PR TITLE
Add CHANGELOG.md linking to Releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+See https://github.com/atom/teletype/releases


### PR DESCRIPTION
Closes #303

---

Following up on the feedback in #303, I've added [release notes for Teletype's last four releases](https://github.com/atom/teletype/releases), and we hope to offer release notes each time we  publish a new release going forward.

To help people discover the release notes, this pull request adds a `CHANGELOG.md` file (based on the feed back in https://github.com/atom/teletype/issues/303#issuecomment-358111953) that links to the Releases page (https://github.com/atom/teletype/releases).
