### PR TITLE
Force stats collection to be disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ module.exports = new TeletypePackage({
   commandRegistry: atom.commands,
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,
-  disableStats: true,
   pusherKey: atom.config.get('teletype.pusherKey'),
   pusherOptions: {
-    cluster: atom.config.get('teletype.pusherCluster')
+    cluster: atom.config.get('teletype.pusherCluster'),
+    disableStats: true
   },
   baseURL: atom.config.get('teletype.baseURL')
 })

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = new TeletypePackage({
   commandRegistry: atom.commands,
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,
+  disableStats: true,
   pusherKey: atom.config.get('teletype.pusherKey'),
   pusherOptions: {
     cluster: atom.config.get('teletype.pusherCluster')


### PR DESCRIPTION
Stats are currently effectively disabled by the Chrome content security policy but we should [explicitly disable them](https://github.com/pusher/pusher-js/tree/v4.1.0#disablestats-boolean) to get rid of the console log warning and to prevent them accidentally becoming enabled should the CSP or implementation change.

If somebody does want to enable them we would need to:

1. Honor the `telemetryConsent` config setting in Atom - would need to be set to `limited` for opt-in
2. Need to modify the CSP to enable this host to get through Chrome