### PR TITLE
Improve diagnostics for package initialization errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,6 @@ module.exports = new TeletypePackage({
     cluster: atom.config.get('teletype.pusherCluster'),
     disableStats: true
   },
-  baseURL: atom.config.get('teletype.baseURL')
+  baseURL: atom.config.get('teletype.baseURL'),
+  getAtomVersion: atom.getVersion.bind(atom)
 })

--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -1,4 +1,5 @@
 const etch = require('etch')
+const {URL} = require('url')
 const $ = etch.dom
 
 module.exports =
@@ -16,7 +17,6 @@ class PackageInitializationErrorComponent {
   render () {
     return $.div({className: 'PackageInitializationErrorComponent'},
       $.h3(null, 'Teletype initialization failed'),
-      $.p(null, 'Error: ' + this.props.initializationError.message),
       $.p(null, 'Make sure your internet connection is working and restart the package.'),
       $.div(null,
         $.button(
@@ -31,10 +31,25 @@ class PackageInitializationErrorComponent {
       ),
       $.p(null,
         'If the problem persists, visit ',
-        $.a({href: 'https://github.com/atom/teletype/issues/new', className: 'text-info'}, 'atom/teletype'),
+        $.a({href: this.getIssueURL(), className: 'text-info'}, 'atom/teletype'),
         ' and open an issue.'
       )
     )
+  }
+
+  getIssueURL () {
+    const {initializationError} = this.props
+
+    const url = new URL('https://github.com/atom/teletype/issues/new')
+    url.searchParams.append('title', 'Package Initialization Error')
+    url.searchParams.append('body',
+      '### Diagnostics\n\n' +
+      '```\n' +
+      initializationError.diagnosticMessage + '\n' +
+      '```\n'
+    )
+
+    return url.href
   }
 
   async restartTeletype () {

--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -45,8 +45,12 @@ class PackageInitializationErrorComponent {
     url.searchParams.append('body',
       '### Diagnostics\n\n' +
       '```\n' +
-      initializationError.diagnosticMessage + '\n' +
-      '```\n'
+      initializationError.diagnosticMessage + '\n\n' +
+      '```\n' +
+      '### Versions\n\n' +
+      `**Teletype version**: v${getTeletypeVersion()}\n` +
+      `**Atom version**: ${this.props.getAtomVersion()}\n` +
+      `**Platform**: ${process.platform}\n`
     )
 
     return url.href
@@ -57,4 +61,8 @@ class PackageInitializationErrorComponent {
     await packageManager.deactivatePackage('teletype')
     await packageManager.activatePackage('teletype')
   }
+}
+
+function getTeletypeVersion () {
+  return require('../package.json').version
 }

--- a/lib/popover-component.js
+++ b/lib/popover-component.js
@@ -23,7 +23,7 @@ class PopoverComponent {
     const {
       isClientOutdated, initializationError,
       authenticationProvider, portalBindingManager,
-      commandRegistry, clipboard, workspace, notificationManager, packageManager
+      commandRegistry, clipboard, workspace, notificationManager, packageManager, getAtomVersion
     } = this.props
 
     let activeComponent
@@ -36,6 +36,7 @@ class PopoverComponent {
       activeComponent = $(PackageInitializationErrorComponent, {
         ref: 'packageInitializationErrorComponent',
         packageManager,
+        getAtomVersion,
         initializationError
       })
     } else if (this.props.authenticationProvider.isSignedIn()) {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -9,9 +9,9 @@ module.exports =
 class TeletypePackage {
   constructor (options) {
     const {
-      baseURL, clipboard, commandRegistry, credentialCache, notificationManager,
-      packageManager, pubSubGateway, pusherKey, pusherOptions,
-      tetherDisconnectWindow, tooltipManager, workspace
+      baseURL, clipboard, commandRegistry, credentialCache, getAtomVersion,
+      notificationManager, packageManager, pubSubGateway, pusherKey,
+      pusherOptions, tetherDisconnectWindow, tooltipManager, workspace
     } = options
 
     this.workspace = workspace
@@ -24,6 +24,7 @@ class TeletypePackage {
     this.pusherKey = pusherKey
     this.pusherOptions = pusherOptions
     this.baseURL = baseURL
+    this.getAtomVersion = getAtomVersion
     this.tetherDisconnectWindow = tetherDisconnectWindow
     this.credentialCache = credentialCache || new CredentialCache()
     this.client = new TeletypeClient({
@@ -132,7 +133,8 @@ class TeletypePackage {
       clipboard: this.clipboard,
       workspace: this.workspace,
       notificationManager: this.notificationManager,
-      packageManager: this.packageManager
+      packageManager: this.packageManager,
+      getAtomVersion: this.getAtomVersion
     })
 
     this.portalStatusBarIndicator.attach()

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.32.0",
+    "@atom/teletype-client": "^0.33.0",
     "etch": "^0.12.6"
   },
   "consumedServices": {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -1101,6 +1101,7 @@ suite('TeletypePackage', function () {
       commandRegistry: env.commands,
       tooltipManager: env.tooltips,
       clipboard: new FakeClipboard(),
+      getAtomVersion: function () { return 'x.y.z' },
       tetherDisconnectWindow: 300,
       credentialCache
     })


### PR DESCRIPTION
To aid in diagnosing and debugging package initialization errors (https://github.com/atom/teletype/issues/266), this pull request incorporates the changes from atom/teletype-client#50 to provide a pre-filled GitHub Issue body with useful diagnostic information. 

For example, clicking on the `atom/teletype` link in the popover...

![screen shot 2018-02-05 at 10 47 28 am](https://user-images.githubusercontent.com/2988/35813602-08e81116-0a62-11e8-856b-a95a32ab6e64.png)

...will prefill an issue like this:

![screen shot 2018-02-05 at 10 47 08 am](https://user-images.githubusercontent.com/2988/35813600-07b8031e-0a62-11e8-8f4e-5d5eb3b93287.png)

### Verification Process

- [x] Simulate a failed _request_ by turning off wi-fi
- [x] Simulate a failed _response_ by hacking the local teletype-server to return a non-JSON response
- [x] Ensure that pointing to the production server still allows successful collaboration in a portal

---

🍐'd with @as-cii 
