### PR TITLE
Close remote buffers on guest when host closes portal

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -28,14 +28,15 @@ class EditorBinding {
 
     this.markerLayersBySiteId.forEach((l) => l.destroy())
     this.markerLayersBySiteId.clear()
-    if (!this.isHost) {
-      this.restoreOriginalEditorMethods(this.editor)
-      this.editor.destroy()
-    }
     if (this.localCursorLayerDecoration) this.localCursorLayerDecoration.destroy()
 
     this.emitter.emit('did-dispose')
     this.emitter.dispose()
+
+    if (!this.isHost) {
+      this.restoreOriginalEditorMethods(this.editor)
+      this.editor.destroy()
+    }
   }
 
   setEditorProxy (editorProxy) {

--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -28,7 +28,10 @@ class EditorBinding {
 
     this.markerLayersBySiteId.forEach((l) => l.destroy())
     this.markerLayersBySiteId.clear()
-    if (!this.isHost) this.restoreOriginalEditorMethods(this.editor)
+    if (!this.isHost) {
+      this.restoreOriginalEditorMethods(this.editor)
+      this.editor.destroy()
+    }
     if (this.localCursorLayerDecoration) this.localCursorLayerDecoration.destroy()
 
     this.emitter.emit('did-dispose')

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -4,6 +4,7 @@ const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const EmptyPortalPaneItem = require('./empty-portal-pane-item')
 const SitePositionsController = require('./site-positions-controller')
+const NOOP = () => {}
 
 module.exports =
 class GuestPortalBinding {
@@ -12,7 +13,7 @@ class GuestPortalBinding {
     this.portalId = portalId
     this.workspace = workspace
     this.notificationManager = notificationManager
-    this.emitDidDispose = didDispose
+    this.emitDidDispose = didDispose || NOOP
     this.lastActivePaneItem = null
     this.editorBindingsByEditorProxy = new Map()
     this.bufferBindingsByBufferProxy = new Map()
@@ -72,19 +73,18 @@ class GuestPortalBinding {
     this.lastEditorProxyChangePromise = this.lastEditorProxyChangePromise.then(async () => {
       const editorBinding = this.editorBindingsByEditorProxy.get(editorProxy)
       if (editorBinding) {
+        const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
+        this.shouldRelayActiveEditorChanges = !isRetracted
+        this.lastDestroyedEditorWasRemovedByHost = true
         editorBinding.dispose()
+        this.lastDestroyedEditorWasRemovedByHost = false
+        this.shouldRelayActiveEditorChanges = true
+
         if (this.editorBindingsByEditorProxy.size === 0) {
           this.portal.follow(1)
         }
 
         await this.toggleEmptyPortalPaneItem()
-
-        const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
-        this.shouldRelayActiveEditorChanges = !isRetracted
-        this.lastDestroyedEditorWasRemovedByHost = true
-        editorBinding.editor.destroy()
-        this.lastDestroyedEditorWasRemovedByHost = false
-        this.shouldRelayActiveEditorChanges = true
       }
     })
 
@@ -228,10 +228,6 @@ class GuestPortalBinding {
   }
 
   leave () {
-    this.editorBindingsByEditorProxy.forEach((binding) => {
-      binding.editor.destroy()
-    })
-
     if (this.portal) this.portal.dispose()
   }
 

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -22,6 +22,7 @@ class GuestPortalBinding {
     this.subscriptions = new CompositeDisposable()
     this.lastEditorProxyChangePromise = Promise.resolve()
     this.shouldRelayActiveEditorChanges = true
+    this.lastDestroyedEditor = null
   }
 
   async initialize () {
@@ -75,9 +76,7 @@ class GuestPortalBinding {
       if (editorBinding) {
         const isRetracted = this.portal.resolveFollowState() === FollowState.RETRACTED
         this.shouldRelayActiveEditorChanges = !isRetracted
-        this.lastDestroyedEditorWasRemovedByHost = true
         editorBinding.dispose()
-        this.lastDestroyedEditorWasRemovedByHost = false
         this.shouldRelayActiveEditorChanges = true
 
         if (this.editorBindingsByEditorProxy.size === 0) {
@@ -144,6 +143,7 @@ class GuestPortalBinding {
       this.editorBindingsByEditorProxy.set(editorProxy, editorBinding)
       this.editorProxiesByEditor.set(editor, editorProxy)
       editorBinding.onDidDispose(() => {
+        this.lastDestroyedEditor = editor
         this.editorProxiesByEditor.delete(editor)
         this.editorBindingsByEditorProxy.delete(editorProxy)
       })
@@ -252,12 +252,12 @@ class GuestPortalBinding {
     }
   }
 
-  didDestroyPaneItem () {
+  didDestroyPaneItem ({item}) {
     const emptyPortalItem = this.getEmptyPortalPaneItem()
     const hasNoPortalPaneItem = this.workspace.getPaneItems().every((item) => (
       item !== emptyPortalItem && !this.editorProxiesByEditor.has(item)
     ))
-    const lastDestroyedEditorWasClosedManually = !this.lastDestroyedEditorWasRemovedByHost
+    const lastDestroyedEditorWasClosedManually = this.lastDestroyedEditor !== item
     if (hasNoPortalPaneItem && lastDestroyedEditorWasClosedManually) {
       this.leave()
     }

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -324,8 +324,18 @@ suite('EditorBinding', function () {
     })
   })
 
+  test('destroys the editor when disposing the binding on guests', () => {
+    const editor = new TextEditor()
+    const binding = new EditorBinding({editor, isHost: false, portal: new FakePortal()})
+    const editorProxy = new FakeEditorProxy(binding)
+    binding.setEditorProxy(editorProxy)
+
+    binding.dispose()
+    assert(editor.isDestroyed())
+  })
+
   suite('guest editor binding', () => {
-    test('overrides the editor methods when setting the proxy, and restores them on dispose', () => {
+    test('overrides the editor methods when setting the proxy', () => {
       const buffer = new TextBuffer({text: SAMPLE_TEXT})
       const editor = new TextEditor({buffer})
 
@@ -343,15 +353,6 @@ suite('EditorBinding', function () {
       editor.save()
       editor.save()
       assert.equal(editorProxy.bufferProxy.saveRequestCount, 2)
-
-      binding.dispose()
-      assert.equal(editor.getTitle(), 'untitled')
-      assert.equal(editor.getURI(), null)
-      assert.notEqual(editor.copy(), null)
-      assert.notEqual(editor.serialize(), null)
-      assert.equal(buffer.getPath(), null)
-      assert(!editor.element.classList.contains('teletype-RemotePaneItem'))
-      assert(editor.getBuffer().isModified())
     })
   })
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -476,48 +476,14 @@ suite('TeletypePackage', function () {
     const hostPortal = await hostPackage.sharePortal()
     await guestPackage.joinPortal(hostPortal.id)
 
-    const hostEditor1 = await hostEnv.workspace.open(path.join(temp.path(), 'file-1'))
-    hostEditor1.setText('const hello = "world"')
-    hostEditor1.setCursorBufferPosition([0, 4])
-    const guestEditor1 = await getNextActiveTextEditorPromise(guestEnv)
+    const hostEditor1 = await hostEnv.workspace.open()
+    await getNextActiveTextEditorPromise(guestEnv)
 
-    const hostEditor2 = await hostEnv.workspace.open(path.join(temp.path(), 'file-2'))
-    hostEditor2.setText('const goodnight = "moon"')
-    hostEditor2.setCursorBufferPosition([0, 2])
-    const guestEditor2 = await getNextActiveTextEditorPromise(guestEnv)
-
-    await condition(() => deepEqual(getCursorDecoratedRanges(hostEditor2), getCursorDecoratedRanges(guestEditor2)))
-    guestEditor2.setCursorBufferPosition([0, 5])
-
-    const guestEditor1TitleChangeEvents = []
-    const guestEditor2TitleChangeEvents = []
-    guestEditor1.onDidChangeTitle((title) => guestEditor1TitleChangeEvents.push(title))
-    guestEditor2.onDidChangeTitle((title) => guestEditor2TitleChangeEvents.push(title))
+    const hostEditor2 = await hostEnv.workspace.open()
+    await getNextActiveTextEditorPromise(guestEnv)
 
     hostPackage.closeHostPortal()
-    await condition(() => guestEditor1.getTitle() === 'untitled' && guestEditor2.getTitle() === 'untitled')
-
-    assert.deepEqual(guestEditor1TitleChangeEvents, ['untitled'])
-    assert.equal(guestEditor1.getText(), 'const hello = "world"')
-    assert(guestEditor1.isModified())
-    assert.deepEqual(getCursorDecoratedRanges(guestEditor1), [
-      {start: {row: 0, column: 4}, end: {row: 0, column: 4}}
-    ])
-
-    assert.deepEqual(guestEditor2TitleChangeEvents, ['untitled'])
-    assert.equal(guestEditor2.getText(), 'const goodnight = "moon"')
-    assert(guestEditor2.isModified())
-    assert.deepEqual(getCursorDecoratedRanges(guestEditor2), [
-      {start: {row: 0, column: 5}, end: {row: 0, column: 5}}
-    ])
-
-    // Ensure that the guest can still edit the buffer or modify selections.
-    guestEditor2.getBuffer().setTextInRange([[0, 0], [0, 5]], 'let')
-    guestEditor2.setCursorBufferPosition([0, 7])
-    assert.equal(guestEditor2.getText(), 'let goodnight = "moon"')
-    assert.deepEqual(getCursorDecoratedRanges(guestEditor2), [
-      {start: {row: 0, column: 7}, end: {row: 0, column: 7}}
-    ])
+    await condition(() => getRemotePaneItems(guestEnv).length === 0)
   })
 
   test('peers undoing their own edits', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -476,10 +476,10 @@ suite('TeletypePackage', function () {
     const hostPortal = await hostPackage.sharePortal()
     await guestPackage.joinPortal(hostPortal.id)
 
-    const hostEditor1 = await hostEnv.workspace.open()
+    await hostEnv.workspace.open()
     await getNextActiveTextEditorPromise(guestEnv)
 
-    const hostEditor2 = await hostEnv.workspace.open()
+    await hostEnv.workspace.open()
     await getNextActiveTextEditorPromise(guestEnv)
 
     hostPackage.closeHostPortal()


### PR DESCRIPTION
### Description of the Change

This change addresses the following item from the task list in https://github.com/atom/teletype/issues/268:

> - [x] Close remote buffers on guest when portal gets closed or disconnected (https://github.com/atom/teletype/commit/9d9f74c11a33e81beca11d5cf16ac4725f1e2d5b#commitcomment-26310833)

In the discussion in https://github.com/atom/teletype/commit/9d9f74c11a33e81beca11d5cf16ac4725f1e2d5b#commitcomment-26310833, we observed that it's often "annoying that the host's buffers persist as unsaved files after they close their portal. With one editor, it was fine, but now there are quite a few tabs to clean up after a host terminates their session." With the changes in this pull request, when the host closes the portal, Teletype will clean up the guest's workspace to remove the closed portal's tabs.

### Verification Process

- [x] When the host closes the portal, verify that all the portal's tabs are closed on the guest
- [x] When a guest is participating in multiple portals (A & B), verify that when portal A is closed by the host, portal A's tabs are closed on the guest, but portal B's tabs remain open on the guest
- [x] When the guest leaves a portal, verify that all the portals tabs are closed on the guest (i.e., the same behavior that existed prior to this pull request)
- [x] When the guest closes the last remote editor for a portal, verify that the guest leaves the portal (i.e., the same behavior that existed prior to this pull request)
- [x] When the host closes the last editor in their workspace, verify that the guest sees the empty portal pane item (i.e., the same behavior that existed prior to this pull request)
