### PR TITLE
🔥 Remove obsolete logic for "deremotifying" guest editors

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -33,10 +33,7 @@ class EditorBinding {
     this.emitter.emit('did-dispose')
     this.emitter.dispose()
 
-    if (!this.isHost) {
-      this.restoreOriginalEditorMethods(this.editor)
-      this.editor.destroy()
-    }
+    if (!this.isHost) this.editor.destroy()
   }
 
   setEditorProxy (editorProxy) {
@@ -84,29 +81,6 @@ class EditorBinding {
     buffer.isModified = () => false
 
     editor.element.classList.add('teletype-RemotePaneItem')
-  }
-
-  restoreOriginalEditorMethods (editor) {
-    const buffer = editor.getBuffer()
-
-    // Deleting the object-level overrides causes future calls to fall back
-    // to original methods stored on the prototypes of the editor and buffer
-    delete editor.getTitle
-    delete editor.getURI
-    delete editor.copy
-    delete editor.serialize
-    delete editor.isRemote
-
-    buffer.remoteEditorCount--
-    if (buffer.remoteEditorCount === 0) {
-      delete buffer.remoteEditorCount
-      delete buffer.getPath
-      delete buffer.save
-      delete buffer.isModified
-    }
-
-    editor.element.classList.remove('teletype-RemotePaneItem')
-    editor.emitter.emit('did-change-title', editor.getTitle())
   }
 
   observeMarker (marker, relay = true) {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -721,7 +721,7 @@ suite('TeletypePackage', function () {
       await editorsEqual(guestEditor1, hostEditor1)
     })
 
-    test('remotifying and deremotifying guest editors and buffers', async () => {
+    test('remotifying guest editors and buffers', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
       const portal = await hostPackage.sharePortal()
@@ -751,14 +751,6 @@ suite('TeletypePackage', function () {
       assert(guestEditor1.isRemote)
       assert(guestEditor1.getTitle().endsWith('a.txt'))
       assert(guestEditor1.getBuffer().getPath().endsWith('a.txt'))
-
-      hostPackage.closeHostPortal()
-
-      await condition(() =>
-        !guestEditor1.isRemote &&
-        guestEditor1.getTitle() === 'untitled' &&
-        guestEditor1.getBuffer().getPath() === undefined
-      )
     })
   })
 


### PR DESCRIPTION
Prior to #319, when the host closed the portal, Teletype would transform the remote editors in the guest's workspace into local untitled/unsaved editors. As of #319, when the host closed the portal, Teletype *closes* remote editors in the guest's workspace. As a result, we no longer need the logic for transforming the remote editors into local editors.

### Verification Process

- [x] As a guest viewing multiple remote editors in a portal, verify that all remote editors are closed when the host closes the portal
- [x] As a guest viewing multiple remote editors in a portal, verify that all remote editors are closed when you leave the portal