### PR TITLE
Reword issue-opening part of the error tooltip

### DIFF
--- a/lib/package-initialization-error-component.js
+++ b/lib/package-initialization-error-component.js
@@ -30,9 +30,9 @@ class PackageInitializationErrorComponent {
         )
       ),
       $.p(null,
-        'If the problem persists, visit ',
-        $.a({href: this.getIssueURL(), className: 'text-info'}, 'atom/teletype'),
-        ' and open an issue.'
+        'If the problem persists, please ',
+        $.a({href: this.getIssueURL(), className: 'text-info'}, 'open an issue'),
+        '.'
       )
     )
   }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide](https://github.com/atom/teletype/blob/master/CONTRIBUTING.md) before submitting any pull requests.**

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Modify the part of the error tooltip that suggests opening an issue.
Before: `If the problem persists, visit [atom/teletype] and open an issue.`
After: `If the problem persists, please [open an issue].`

### Alternate Designs

Alternate wording.  I am open to suggestions.

### Benefits

I think this makes it clearer that the issue will be prefilled rather than asking you to fill out the information yourself.

### Possible Drawbacks

Loss of `atom/teletype` in the issue message.

### Verification Process

Turn off internet and look at the error component.  Click on the "open an issue" part to make sure it leads to a prefilled issue template.

### Applicable Issues

https://github.com/atom/teletype/pull/317#issuecomment-363161822