### PR TITLE
Don't relay selections that are destroyed when creation event is emitted

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -84,6 +84,8 @@ class EditorBinding {
   }
 
   observeMarker (marker, relay = true) {
+    if (marker.isDestroyed()) return
+
     const didChangeDisposable = marker.onDidChange(({textChanged}) => {
       if (textChanged) {
         if (marker.getRange().isEmpty()) marker.clearTail()

--- a/test/editor-binding.test.js
+++ b/test/editor-binding.test.js
@@ -301,6 +301,25 @@ suite('EditorBinding', function () {
     })
   })
 
+  // Refs: https://github.com/atom/text-buffer/pull/210
+  // TODO: Remove this workaround when the bug is fixed on Atom stable.
+  test('does not relay selections that are already destroyed when their creation event is emitted', () => {
+    const editor = new TextEditor({buffer: new TextBuffer(SAMPLE_TEXT)})
+    const binding = new EditorBinding({editor, portal: new FakePortal()})
+    const editorProxy = new FakeEditorProxy(binding)
+    binding.setEditorProxy(editorProxy)
+
+    editor.setSelectedBufferRange([[0, 2], [0, 6]])
+    editor.addSelectionForBufferRange([[0, 3], [0, 9]])
+    assert.deepEqual(editorProxy.selections, {
+      1: {
+        range: {start: {row: 0, column: 2}, end: {row: 0, column: 9}},
+        exclusive: false,
+        reversed: false
+      }
+    })
+  })
+
   suite('destroying the editor', () => {
     test('on the host, disposes the underlying editor proxy', () => {
       const editor = new TextEditor()


### PR DESCRIPTION
This is a workaround to a [bug that exists in Atom core](https://github.com/atom/text-buffer/pull/210) where, if a marker is destroyed during the handling of an `onDidCreateMarker` event, subsequent observers are still notified of the creation event, even though the marker is already destroyed.

This happens frequently when two selections overlap, whereby Atom merges the selections, destroying the most recent one inside of an `onDidCreateMarker` event handler. This should likely be fixed in Atom core (i.e., when iterating over observers to notify them of marker creation, if any observer causes the marker to be destroyed, don't notify the remaining observers).

In the meantime, this feels like a reasonable workaround for Teletype, and will prevent participants from seeing spurious cursors when another participant creates selections that end up overlapping with each other.

### Demo of the bug this change resolves

In the gif below, the top window is the host and the bottom window is the guest.

1. Notice that the guest is following the host.
1. The host selects the word `async` on line 207 and then holds down <kbd>command</kbd>+<kbd>d</kbd> to select the other occurrences of `async` in the buffer
1. The host then hits <kbd>escape</kbd>.
1. At this point, the host has just one cursor. That cursor is on line 207, and that line is at the center of the host's viewport. The guest is still tethered to the host, but the guest incorrectly sees a cursor for the host on line 1, and therefore the guest's viewport is incorrectly focused on line 1. Instead, the guest should see the host's cursor on line 207, and line 207 should be at the center of the guest's viewport. 


![demo](https://user-images.githubusercontent.com/2988/36180805-eb844646-10ef-11e8-88d4-f033586f18ce.gif)
