### PR TITLE
Updated license year in LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017 GitHub
+Copyright (c) 2017-2018 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Updated the LICENSE.md file from

```
Copyright (c) 2017 GitHub
```

to

```
Copyright (c) 2017-2018 GitHub Inc.
```

Used this for reference
LICENSE.md file of atom's repo: https://github.com/atom/atom/blob/master/LICENSE.md

### Alternate Designs

None

### Benefits

Correct license year in LICENSE.md

### Possible Drawbacks

None

### Verification Process

Checked the LICENSE.md file to display the right year

### Applicable Issues

Fixes #330 