### PR TITLE
Join portal via URL (Part 1)

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const {Range, Emitter, Disposable, CompositeDisposable} = require('atom')
 const getPathWithNativeSeparators = require('./get-path-with-native-separators')
-const getEditorURI = require('./get-editor-uri')
+const {getEditorURI} = require('./uri-helpers')
 const {FollowState} = require('@atom/teletype-client')
 
 module.exports =

--- a/lib/get-editor-uri.js
+++ b/lib/get-editor-uri.js
@@ -1,3 +1,0 @@
-module.exports = function getEditorURI (portalId, editorProxyId) {
-  return 'atom://teletype/portal/' + portalId + '/editor/' + editorProxyId
-}

--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -4,7 +4,7 @@ const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const SitePositionsComponent = require('./site-positions-component')
 const getPathWithNativeSeparators = require('./get-path-with-native-separators')
-const getEditorURI = require('./get-editor-uri')
+const {getEditorURI} = require('./uri-helpers')
 const NOOP = () => {}
 
 module.exports =

--- a/lib/is-uuid.js
+++ b/lib/is-uuid.js
@@ -1,4 +1,0 @@
-const UUID_REGEXP = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/
-module.exports = function isUUID (string) {
-  return UUID_REGEXP.test(string)
-}

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -1,7 +1,7 @@
 const etch = require('etch')
 const $ = etch.dom
 const {TextEditor} = require('atom')
-const isUUID = require('./is-uuid')
+const {isPortalId} = require('./portal-id-helpers')
 
 module.exports =
 class JoinPortalComponent {
@@ -31,7 +31,7 @@ class JoinPortalComponent {
     if (!previousPortalIdEditor && this.portalIdEditor) {
       this.portalIdEditor.onDidChange(() => {
         const portalId = this.refs.portalIdEditor.getText().trim()
-        this.refs.joinButton.disabled = !isUUID(portalId)
+        this.refs.joinButton.disabled = !isPortalId(portalId)
       })
     }
   }
@@ -69,7 +69,7 @@ class JoinPortalComponent {
 
     let clipboardText = this.props.clipboard.read()
     if (clipboardText) clipboardText = clipboardText.trim()
-    if (isUUID(clipboardText)) {
+    if (isPortalId(clipboardText)) {
       this.refs.portalIdEditor.setText(clipboardText)
     }
     this.refs.portalIdEditor.element.focus()
@@ -83,7 +83,7 @@ class JoinPortalComponent {
     const {portalBindingManager} = this.props
     const portalId = this.refs.portalIdEditor.getText().trim()
 
-    if (!isUUID(portalId)) {
+    if (!isPortalId(portalId)) {
       this.props.notificationManager.addError('Invalid portal ID format', {
         description: 'This doesn\'t look like a valid portal ID. Please ask your host to provide you with their current portal ID and try again.',
         dismissable: true

--- a/lib/portal-binding-manager.js
+++ b/lib/portal-binding-manager.js
@@ -1,7 +1,7 @@
 const {Emitter} = require('atom')
 const HostPortalBinding = require('./host-portal-binding')
 const GuestPortalBinding = require('./guest-portal-binding')
-const isUUID = require('./is-uuid')
+const {isPortalId} = require('./portal-id-helpers')
 
 module.exports =
 class PortalBindingManager {
@@ -138,7 +138,7 @@ class PortalBindingManager {
     const uriComponents = uri.replace('atom://teletype/', '').split('/')
 
     const portalId = uriComponents[1]
-    if (uriComponents[0] !== 'portal' || !isUUID(portalId)) return null
+    if (uriComponents[0] !== 'portal' || !isPortalId(portalId)) return null
 
     const editorProxyId = Number(uriComponents[3])
     if (uriComponents[2] !== 'editor' || Number.isNaN(editorProxyId)) return null

--- a/lib/portal-id-helpers.js
+++ b/lib/portal-id-helpers.js
@@ -1,0 +1,12 @@
+function findPortalId (string) {
+  const CONTAINS_UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+  const match = string.match(CONTAINS_UUID_REGEXP)
+  return match ? match[0] : null
+}
+
+function isPortalId (string) {
+  const IS_UUID_REGEXP = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/
+  return IS_UUID_REGEXP.test(string)
+}
+
+module.exports = {findPortalId, isPortalId}

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -57,6 +57,9 @@ class TeletypePackage {
       'teletype:leave-portal': () => this.leavePortal()
     }))
     this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
+      'teletype:copy-portal-url': () => this.copyHostPortalURL()
+    }))
+    this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
       'teletype:close-portal': () => this.closeHostPortal()
     }))
 
@@ -78,6 +81,12 @@ class TeletypePackage {
       const manager = await this.portalBindingManagerPromise
       await manager.dispose()
     }
+  }
+
+  handleURI (parsedURI) {
+    const UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+    const match = parsedURI.pathname.match(UUID_REGEXP)
+    this.joinPortal(match[0])
   }
 
   async sharePortal () {
@@ -110,6 +119,13 @@ class TeletypePackage {
     const manager = await this.getPortalBindingManager()
     const hostPortalBinding = await manager.getHostPortalBinding()
     hostPortalBinding.close()
+  }
+
+  async copyHostPortalURL () {
+    const manager = await this.getPortalBindingManager()
+    const hostPortalBinding = await manager.getHostPortalBinding()
+    const url = `atom://teletype/portal/${hostPortalBinding.portal.id}`
+    atom.clipboard.write(url)
   }
 
   async leavePortal () {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -13,8 +13,9 @@ class TeletypePackage {
   constructor (options) {
     const {
       baseURL, clipboard, commandRegistry, credentialCache, getAtomVersion,
-      notificationManager, packageManager, pubSubGateway, pusherKey,
-      pusherOptions, tetherDisconnectWindow, tooltipManager, workspace
+      notificationManager, packageManager, peerConnectionTimeout, pubSubGateway,
+      pusherKey, pusherOptions, tetherDisconnectWindow, tooltipManager,
+      workspace
     } = options
 
     this.workspace = workspace
@@ -28,6 +29,7 @@ class TeletypePackage {
     this.pusherOptions = pusherOptions
     this.baseURL = baseURL
     this.getAtomVersion = getAtomVersion
+    this.peerConnectionTimeout = peerConnectionTimeout
     this.tetherDisconnectWindow = tetherDisconnectWindow
     this.credentialCache = credentialCache || new CredentialCache()
     this.client = new TeletypeClient({
@@ -35,6 +37,7 @@ class TeletypePackage {
       pusherOptions: this.pusherOptions,
       baseURL: this.baseURL,
       pubSubGateway: this.pubSubGateway,
+      connectionTimeout: this.peerConnectionTimeout,
       tetherDisconnectWindow: this.tetherDisconnectWindow
     })
     this.client.onConnectionError(this.handleConnectionError.bind(this))

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -85,9 +85,15 @@ class TeletypePackage {
   }
 
   handleURI (parsedURI) {
-    const UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
-    const match = parsedURI.pathname.match(UUID_REGEXP)
-    this.joinPortal(match[0])
+    const findUUID = function (str) {
+      const UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+      const match = str.match(UUID_REGEXP)
+      return match ? match[0] : null
+    }
+
+    const pathname = parsedURI.pathname
+    const joinable = findUUID(pathname) || pathname
+    this.joinPortal(joinable)
   }
 
   async sharePortal () {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -87,7 +87,7 @@ class TeletypePackage {
 
   handleURI (parsedURI, rawURI) {
     const portalId = findPortalId(parsedURI.pathname) || rawURI
-    this.joinPortal(portalId)
+    return this.joinPortal(portalId)
   }
 
   async sharePortal () {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -5,6 +5,7 @@ const PortalStatusBarIndicator = require('./portal-status-bar-indicator')
 const AuthenticationProvider = require('./authentication-provider')
 const CredentialCache = require('./credential-cache')
 const TeletypeService = require('./teletype-service')
+const {findPortalId} = require('./portal-id-helpers')
 const {getPortalURI} = require('./uri-helpers')
 
 module.exports =
@@ -84,16 +85,9 @@ class TeletypePackage {
     }
   }
 
-  handleURI (parsedURI) {
-    const findUUID = function (str) {
-      const UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
-      const match = str.match(UUID_REGEXP)
-      return match ? match[0] : null
-    }
-
-    const pathname = parsedURI.pathname
-    const joinable = findUUID(pathname) || pathname
-    this.joinPortal(joinable)
+  handleURI (parsedURI, rawURI) {
+    const portalId = findPortalId(parsedURI.pathname) || rawURI
+    this.joinPortal(portalId)
   }
 
   async sharePortal () {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -5,6 +5,7 @@ const PortalStatusBarIndicator = require('./portal-status-bar-indicator')
 const AuthenticationProvider = require('./authentication-provider')
 const CredentialCache = require('./credential-cache')
 const TeletypeService = require('./teletype-service')
+const {getPortalURI} = require('./uri-helpers')
 
 module.exports =
 class TeletypePackage {
@@ -124,7 +125,7 @@ class TeletypePackage {
   async copyHostPortalURL () {
     const manager = await this.getPortalBindingManager()
     const hostPortalBinding = await manager.getHostPortalBinding()
-    const url = `atom://teletype/portal/${hostPortalBinding.portal.id}`
+    const url = getPortalURI(hostPortalBinding.portal.id)
     atom.clipboard.write(url)
   }
 

--- a/lib/uri-helpers.js
+++ b/lib/uri-helpers.js
@@ -1,0 +1,9 @@
+function getPortalURI (portalId) {
+  return 'atom://teletype/portal/' + portalId
+}
+
+function getEditorURI (portalId, editorProxyId) {
+  return getPortalURI(portalId) + '/editor/' + editorProxyId
+}
+
+module.exports = {getEditorURI, getPortalURI}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
       }
     }
   },
+  "uriHandler": {
+    "method": "handleURI",
+    "deferActivation": false
+  },
   "engines": {
     "atom": ">=1.22.0"
   },

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -128,6 +128,17 @@ suite('TeletypePackage', function () {
       assert.equal(getRemotePaneItems(guestEnv).length, 1)
     })
 
+    test('opening URI for nonexistent portal', async () => {
+      const pack = await buildPackage(buildAtomEnvironment())
+      const notifications = []
+      pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
+
+      const uri = 'atom://teletype/portal/00000000-0000-0000-0000-000000000000'
+      const portal = await handleURI(pack, uri)
+      assert(!portal)
+      await condition(() => notifications.find((n) => n.message === 'Portal not found'))
+    })
+
     test('opening URI for inaccessible portal', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
@@ -145,17 +156,6 @@ suite('TeletypePackage', function () {
       const guestPortal = await handleURI(guestPackage, uri)
       assert(!guestPortal)
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
-    })
-
-    test('opening URI for nonexistent portal', async () => {
-      const pack = await buildPackage(buildAtomEnvironment())
-      const notifications = []
-      pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
-
-      const uri = 'atom://teletype/portal/00000000-0000-0000-0000-000000000000'
-      const portal = await handleURI(pack, uri)
-      assert(!portal)
-      await condition(() => notifications.find((n) => n.message === 'Portal not found'))
     })
 
     test('opening malformed URI', async () => {

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -166,6 +166,7 @@ suite('TeletypePackage', function () {
       let portal = await handleURI(pack, 'atom://teletype/some-unsupported-uri')
       assert(!portal)
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
+      notifications.length = 0
 
       portal = await handleURI(pack, 'atom://teletype/portal/42')
       assert(!portal)

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -153,7 +153,8 @@ suite('TeletypePackage', function () {
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
       const uri = 'atom://teletype/portal/00000000-0000-0000-0000-000000000000'
-      handleURI(pack, uri)
+      const portal = await handleURI(pack, uri)
+      assert(!portal)
       await condition(() => notifications.find((n) => n.message === 'Portal not found'))
     })
 
@@ -162,10 +163,12 @@ suite('TeletypePackage', function () {
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
-      handleURI(pack, 'atom://teletype/some-unsupported-uri')
+      let portal = await handleURI(pack, 'atom://teletype/some-unsupported-uri')
+      assert(!portal)
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
 
-      handleURI(pack, 'atom://teletype/portal/42')
+      portal = await handleURI(pack, 'atom://teletype/portal/42')
+      assert(!portal)
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
     })
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -109,8 +109,7 @@ suite('TeletypePackage', function () {
   })
 
   suite('portal URIs', () => {
-    // TODO Can we replace this with something like `await guestEnv.workspace.open(uri)` ?
-    function joinPortal (pack, uri) {
+    function handleURI (pack, uri) {
       pack.handleURI(url.parse(uri), uri)
     }
 
@@ -124,7 +123,7 @@ suite('TeletypePackage', function () {
       const uri = `atom://teletype/portal/${portal.id}`
       await hostEnv.workspace.open()
 
-      joinPortal(guestPackage, uri)
+      handleURI(guestPackage, uri)
       await condition(() => getRemotePaneItems(guestEnv).length === 1)
     })
 
@@ -142,7 +141,7 @@ suite('TeletypePackage', function () {
       const uri = `atom://teletype/portal/${portal.id}`
       await hostPackage.closeHostPortal()
 
-      joinPortal(guestPackage, uri)
+      handleURI(guestPackage, uri)
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
     })
 
@@ -152,7 +151,7 @@ suite('TeletypePackage', function () {
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
       const uri = 'atom://teletype/portal/00000000-0000-0000-0000-000000000000'
-      joinPortal(pack, uri)
+      handleURI(pack, uri)
       await condition(() => notifications.find((n) => n.message === 'Portal not found'))
     })
 
@@ -161,10 +160,10 @@ suite('TeletypePackage', function () {
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
-      joinPortal(pack, 'atom://teletype/some-unsupported-uri')
+      handleURI(pack, 'atom://teletype/some-unsupported-uri')
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
 
-      joinPortal(pack, 'atom://teletype/portal/42')
+      handleURI(pack, 'atom://teletype/portal/42')
       await condition(() => notifications.find((n) => n.message === 'Failed to join portal'))
     })
 


### PR DESCRIPTION
### Description

This pull request implements the following item from the task list in https://github.com/atom/teletype/issues/109:

> - [ ] Teach Teletype to join portal via URL
>     - Add URI handler
>     - Add command for getting the URL
>     - Automatically join the portal when URL is followed (for now)
>     - Don't provide any UI for getting the URL (for now)

This is the first in a series of pull requests that will implement the various aspects described in https://github.com/atom/teletype/issues/109. Once all items in that task list have been addressed, we'll publish a new Teletype release with support for joining a portal via a URL.

### Demo

![demo](https://user-images.githubusercontent.com/2988/37676053-3ec39438-2c4d-11e8-8d28-00c73ce6edc4.gif)

### TODO

- [x] Add basic support for joining portal via URL
- [x] Resolve all TODOs present in the diff

### Verification process

- [ ] Can use `Teletype: Copy Portal Url` command to copy URL when hosting a portal
- [ ] `Teletype: Copy Portal Url` command is not available when not hosting a portal
- [ ] Following valid portal URL launches Atom and joins portal
- [ ] Following the same URL multiple times has no effect
- [ ] Following a malformed URL results in an error notification
    - `atom://teletype/portal/42`
    - `atom://teletype/whoops`
    - `atom://teletype/`
    - `atom://teletype`
- [ ] Following a URL to join your own portal results in an error notification
- [ ] Following a URL to join a closed portal results in an error notification
- [ ] Following a URL to join a portal when signed out of Teletype displays the "sign in" popup

### Applicable Issues

#109 
#344 
