### PR TITLE
Join portal via URL (Part 2)

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -197,11 +197,13 @@ class GuestPortalBinding {
     let message, description
     if (error instanceof Errors.PortalNotFoundError) {
       message = 'Portal not found'
-      description = 'No portal exists with that ID. Please ask your host to provide you with their current portal ID.'
+      description =
+        'The portal you were trying to join does not exist. ' +
+        'Please ask your host to provide you with their current portal URL.'
     } else {
       message = 'Failed to join portal'
       description =
-        `Attempting to join portal ${this.portalId} failed with error: <code>${error.message}</code>\n\n` +
+        `Attempting to join portal failed with error: <code>${error.message}</code>\n\n` +
         'Please wait a few moments and try again.'
     }
     this.notificationManager.addError(message, {

--- a/lib/host-portal-binding-component.js
+++ b/lib/host-portal-binding-component.js
@@ -114,8 +114,7 @@ class HostPortalBindingComponent {
 
   getPortalURI () {
     if (this.props.portalBinding) {
-      const id = this.props.portalBinding.portal.id
-      return require('./uri-helpers').getPortalURI(id)
+      return this.props.portalBinding.uri
     }
   }
 }

--- a/lib/host-portal-binding-component.js
+++ b/lib/host-portal-binding-component.js
@@ -65,10 +65,10 @@ class HostPortalBindingComponent {
       return $.div({className: 'HostPortalComponent-connection-info'},
         creatingPortal ? this.renderCreatingPortalSpinner() : null,
         $.div({className: 'HostPortalComponent-connection-info-heading ' + statusClassName},
-          $.h1(null, 'Invite collaborators to join your portal with this ID')
+          $.h1(null, 'Invite collaborators to join your portal with this URL')
         ),
-        $.div({className: 'HostPortalComponent-connection-info-portal-id ' + statusClassName},
-          $.input({className: 'input-text host-id-input', type: 'text', disabled: true, value: this.getPortalId()}),
+        $.div({className: 'HostPortalComponent-connection-info-portal-url ' + statusClassName},
+          $.input({className: 'input-text host-id-input', type: 'text', disabled: true, value: this.getPortalURI()}),
           $.button({className: 'btn btn-xs', onClick: this.copyPortalIdToClipboard}, copyButtonText)
         )
       )
@@ -93,7 +93,7 @@ class HostPortalBindingComponent {
 
   copyPortalIdToClipboard () {
     const {clipboard} = this.props
-    clipboard.write(this.getPortalId())
+    clipboard.write(this.getPortalURI())
 
     if (this.copiedConfirmationResetTimeoutId) {
       clearTimeout(this.copiedConfirmationResetTimeoutId)
@@ -112,9 +112,10 @@ class HostPortalBindingComponent {
     return this.props.portalBinding != null
   }
 
-  getPortalId () {
+  getPortalURI () {
     if (this.props.portalBinding) {
-      return this.props.portalBinding.portal.id
+      const id = this.props.portalBinding.portal.id
+      return require('./uri-helpers').getPortalURI(id)
     }
   }
 }

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -4,6 +4,7 @@ const {FollowState} = require('@atom/teletype-client')
 const BufferBinding = require('./buffer-binding')
 const EditorBinding = require('./editor-binding')
 const SitePositionsComponent = require('./site-positions-component')
+const {getPortalURI} = require('./uri-helpers')
 
 module.exports =
 class HostPortalBinding {
@@ -25,6 +26,7 @@ class HostPortalBinding {
       this.portal = await this.client.createPortal()
       if (!this.portal) return false
 
+      this.uri = getPortalURI(this.portal.id)
       this.sitePositionsComponent = new SitePositionsComponent({portal: this.portal, workspace: this.workspace})
 
       this.portal.setDelegate(this)

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -84,8 +84,8 @@ class JoinPortalComponent {
     const portalId = findPortalId(this.refs.portalIdEditor.getText().trim())
 
     if (!portalId) {
-      this.props.notificationManager.addError('Invalid portal ID format', {
-        description: 'This doesn\'t look like a valid portal ID. Please ask your host to provide you with their current portal ID and try again.',
+      this.props.notificationManager.addError('Invalid format', {
+        description: 'This doesn\'t look like a valid portal identifier. Please ask your host to provide you with their current portal URL and try again.',
         dismissable: true
       })
       return

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -54,7 +54,7 @@ class JoinPortalComponent {
       )
     } else if (promptVisible) {
       return $.div({className: 'JoinPortalComponent--prompt', tabIndex: -1},
-        $(TextEditor, {ref: 'portalIdEditor', mini: true, placeholderText: 'Enter a host portal ID...'}),
+        $(TextEditor, {ref: 'portalIdEditor', mini: true, placeholderText: 'Enter a portal URL...'}),
         $.button({ref: 'joinButton', type: 'button', disabled: true, className: 'btn btn-xs', onClick: this.joinPortal}, 'Join')
       )
     } else {

--- a/lib/join-portal-component.js
+++ b/lib/join-portal-component.js
@@ -1,7 +1,7 @@
 const etch = require('etch')
 const $ = etch.dom
 const {TextEditor} = require('atom')
-const {isPortalId} = require('./portal-id-helpers')
+const {findPortalId} = require('./portal-id-helpers')
 
 module.exports =
 class JoinPortalComponent {
@@ -31,7 +31,7 @@ class JoinPortalComponent {
     if (!previousPortalIdEditor && this.portalIdEditor) {
       this.portalIdEditor.onDidChange(() => {
         const portalId = this.refs.portalIdEditor.getText().trim()
-        this.refs.joinButton.disabled = !isPortalId(portalId)
+        this.refs.joinButton.disabled = !findPortalId(portalId)
       })
     }
   }
@@ -69,7 +69,7 @@ class JoinPortalComponent {
 
     let clipboardText = this.props.clipboard.read()
     if (clipboardText) clipboardText = clipboardText.trim()
-    if (isPortalId(clipboardText)) {
+    if (findPortalId(clipboardText)) {
       this.refs.portalIdEditor.setText(clipboardText)
     }
     this.refs.portalIdEditor.element.focus()
@@ -81,9 +81,9 @@ class JoinPortalComponent {
 
   async joinPortal () {
     const {portalBindingManager} = this.props
-    const portalId = this.refs.portalIdEditor.getText().trim()
+    const portalId = findPortalId(this.refs.portalIdEditor.getText().trim())
 
-    if (!isPortalId(portalId)) {
+    if (!portalId) {
       this.props.notificationManager.addError('Invalid portal ID format', {
         description: 'This doesn\'t look like a valid portal ID. Please ask your host to provide you with their current portal ID and try again.',
         dismissable: true

--- a/lib/portal-binding-manager.js
+++ b/lib/portal-binding-manager.js
@@ -1,7 +1,7 @@
 const {Emitter} = require('atom')
 const HostPortalBinding = require('./host-portal-binding')
 const GuestPortalBinding = require('./guest-portal-binding')
-const {isPortalId} = require('./portal-id-helpers')
+const {findPortalId} = require('./portal-id-helpers')
 
 module.exports =
 class PortalBindingManager {
@@ -137,8 +137,8 @@ class PortalBindingManager {
   async getRemoteEditorForURI (uri) {
     const uriComponents = uri.replace('atom://teletype/', '').split('/')
 
-    const portalId = uriComponents[1]
-    if (uriComponents[0] !== 'portal' || !isPortalId(portalId)) return null
+    const portalId = findPortalId(uriComponents[1])
+    if (uriComponents[0] !== 'portal' || !portalId) return null
 
     const editorProxyId = Number(uriComponents[3])
     if (uriComponents[2] !== 'editor' || Number.isNaN(editorProxyId)) return null

--- a/lib/portal-id-helpers.js
+++ b/lib/portal-id-helpers.js
@@ -1,12 +1,10 @@
+const CONTAINS_UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+
 function findPortalId (string) {
-  const CONTAINS_UUID_REGEXP = /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
+  if (!string) return null
+
   const match = string.match(CONTAINS_UUID_REGEXP)
   return match ? match[0] : null
 }
 
-function isPortalId (string) {
-  const IS_UUID_REGEXP = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/
-  return IS_UUID_REGEXP.test(string)
-}
-
-module.exports = {findPortalId, isPortalId}
+module.exports = {findPortalId}

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -6,7 +6,6 @@ const AuthenticationProvider = require('./authentication-provider')
 const CredentialCache = require('./credential-cache')
 const TeletypeService = require('./teletype-service')
 const {findPortalId} = require('./portal-id-helpers')
-const {getPortalURI} = require('./uri-helpers')
 
 module.exports =
 class TeletypePackage {
@@ -62,7 +61,7 @@ class TeletypePackage {
       'teletype:leave-portal': () => this.leavePortal()
     }))
     this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
-      'teletype:copy-portal-url': () => this.copyHostPortalURL()
+      'teletype:copy-portal-url': () => this.copyHostPortalURI()
     }))
     this.subscriptions.add(this.commandRegistry.add('atom-workspace.teletype-Host', {
       'teletype:close-portal': () => this.closeHostPortal()
@@ -125,11 +124,10 @@ class TeletypePackage {
     hostPortalBinding.close()
   }
 
-  async copyHostPortalURL () {
+  async copyHostPortalURI () {
     const manager = await this.getPortalBindingManager()
     const hostPortalBinding = await manager.getHostPortalBinding()
-    const url = getPortalURI(hostPortalBinding.portal.id)
-    atom.clipboard.write(url)
+    atom.clipboard.write(hostPortalBinding.uri)
   }
 
   async leavePortal () {

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -162,7 +162,7 @@
       }
     }
 
-    &-portal-id {
+    &-portal-url {
       display: flex;
       flex-direction: row;
       margin-bottom: 5px;

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -88,6 +88,7 @@ suite('PortalListComponent', function () {
     assert(!hostPortalBindingComponent.refs.creatingPortalSpinner)
   })
 
+  // TODO We probably want to add to and/or change these tests
   test('joining portals', async () => {
     const {component} = await buildComponent()
     const {joinPortalComponent, guestPortalBindingsContainer} = component.refs
@@ -177,6 +178,7 @@ suite('PortalListComponent', function () {
     assert(queryParticipantElement(guestPortalBindingsContainer, 3))
   })
 
+  // TODO We probably want to change and/or add to these tests
   test('prefilling portal ID from clipboard', async () => {
     const {component} = await buildComponent()
     const {clipboard} = component.props

--- a/test/portal-list-component.test.js
+++ b/test/portal-list-component.test.js
@@ -197,28 +197,27 @@ suite('PortalListComponent', function () {
     assert(queryParticipantElement(guestPortalBindingsContainer, 3))
   })
 
-  // TODO We probably want to change and/or add to these tests
-  test('prefilling portal ID from clipboard', async () => {
+  test('prefilling portal URI from clipboard', async () => {
     const {component} = await buildComponent()
     const {clipboard} = component.props
     const {joinPortalComponent} = component.refs
 
-    // Clipboard containing a portal ID
-    clipboard.write('bc282ad8-7643-42cb-80ca-c243771a618f')
+    // Clipboard containing a portal URI
+    clipboard.write('atom://teletype/portal/bc282ad8-7643-42cb-80ca-c243771a618f')
     await joinPortalComponent.showPrompt()
 
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'bc282ad8-7643-42cb-80ca-c243771a618f')
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'atom://teletype/portal/bc282ad8-7643-42cb-80ca-c243771a618f')
 
-    // Clipboard containing a portal ID with surrounding whitespace
+    // Clipboard containing a portal URI with surrounding whitespace
     await joinPortalComponent.hidePrompt()
-    clipboard.write('\te40fa1b5-8144-4d09-9dff-c26e7b10b366  \n')
+    clipboard.write('\tatom://teletype/portal/e40fa1b5-8144-4d09-9dff-c26e7b10b366  \n')
     await joinPortalComponent.showPrompt()
 
-    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'e40fa1b5-8144-4d09-9dff-c26e7b10b366')
+    assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), 'atom://teletype/portal/e40fa1b5-8144-4d09-9dff-c26e7b10b366')
 
-    // Clipboard containing something that is NOT a portal ID
+    // Clipboard containing something that is NOT a portal URI
     await joinPortalComponent.hidePrompt()
-    clipboard.write('not a portal id')
+    clipboard.write('atom://not-a-portal-uri')
     await joinPortalComponent.showPrompt()
 
     assert.equal(joinPortalComponent.refs.portalIdEditor.getText(), '')

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -474,7 +474,6 @@ suite('TeletypePackage', function () {
     assert(!env.workspace.element.classList.contains('teletype-Authenticated'))
   })
 
-  // TODO We probably want to update this test
   test('prompting for a portal URL when joining', async () => {
     const pack = await buildPackage(buildAtomEnvironment())
     await pack.consumeStatusBar(new FakeStatusBar())

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -474,7 +474,8 @@ suite('TeletypePackage', function () {
     assert(!env.workspace.element.classList.contains('teletype-Authenticated'))
   })
 
-  test('prompting for a portal ID when joining', async () => {
+  // TODO We probably want to update this test
+  test('prompting for a portal URL when joining', async () => {
     const pack = await buildPackage(buildAtomEnvironment())
     await pack.consumeStatusBar(new FakeStatusBar())
 


### PR DESCRIPTION
### Description of the Change

This pull request is a follow-up to #346 and changes the UI to accept and show portal URIs instead of just their IDs. This has the advantage of uniforming the ways a portal can be shared and joined. For backward compatibility, we will still accept and parse portal IDs. The following are a few highlights of the proposed UI changes:

<p align="center">
<img src="https://user-images.githubusercontent.com/482957/37702950-6cda2c04-2cf4-11e8-8819-20815154c183.png" />
<img src="https://user-images.githubusercontent.com/482957/37702947-6ca09408-2cf4-11e8-9592-c68fbf505af6.png" />
<img src="https://user-images.githubusercontent.com/482957/37702949-6cbdb826-2cf4-11e8-8a7a-9cccb88f8ceb.png" />
</p>


### Possible Drawbacks

This new code does not really validate that the supplied URL has the right prefix (i.e., starts with `atom://teletype/portal/`), but literally just attempts to extract a UUID from a string. One downside of this is that users may accidentally paste a URL belonging to a different website/service. We think this is okay because the odds of it happening are relatively low and, even if it happens sometimes, it will be a non-destructive action.

### Verification Process

* Share and join a portal using URLs via the popover.
  * Ensure pre-filling from clipboard works.
  * Ensure portal is joined correctly.
* Share and join a portal using IDs via the popover.
  * Ensure pre-filling from clipboard works.
  * Ensure portal is joined correctly.
* Join a portal with a valid URL or ID but that does not exist.
* Join a portal with a malformed URL or ID.

### Applicable Issues

#344 
https://github.com/atom/teletype/pull/344#discussion_r175438235