### PR TITLE
Join portal via URL (Part 3 of 3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ module.exports = new TeletypePackage({
   commandRegistry: atom.commands,
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,
-  pusherKey: atom.config.get('teletype.pusherKey'),
+  pusherKey: atom.config.get('teletype.dev.pusherKey'),
   pusherOptions: {
-    cluster: atom.config.get('teletype.pusherCluster'),
+    cluster: atom.config.get('teletype.dev.pusherCluster'),
     disableStats: true
   },
-  baseURL: atom.config.get('teletype.baseURL'),
+  baseURL: atom.config.get('teletype.dev.baseURL'),
   getAtomVersion: atom.getVersion.bind(atom)
 })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const TeletypePackage = require('./lib/teletype-package')
 module.exports = new TeletypePackage({
+  config: atom.config,
   workspace: atom.workspace,
   notificationManager: atom.notifications,
   packageManager: atom.packages,

--- a/lib/host-portal-binding-component.js
+++ b/lib/host-portal-binding-component.js
@@ -69,7 +69,7 @@ class HostPortalBindingComponent {
         ),
         $.div({className: 'HostPortalComponent-connection-info-portal-url ' + statusClassName},
           $.input({className: 'input-text host-id-input', type: 'text', disabled: true, value: this.getPortalURI()}),
-          $.button({className: 'btn btn-xs', onClick: this.copyPortalIdToClipboard}, copyButtonText)
+          $.button({className: 'btn btn-xs', onClick: this.copyPortalURLToClipboard}, copyButtonText)
         )
       )
     } else {
@@ -91,7 +91,7 @@ class HostPortalBindingComponent {
     }
   }
 
-  copyPortalIdToClipboard () {
+  copyPortalURLToClipboard () {
     const {clipboard} = this.props
     clipboard.write(this.getPortalURI())
 

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -1,0 +1,68 @@
+const etch = require('etch')
+const $ = etch.dom
+const {TextEditor} = require('atom')
+
+module.exports =
+class JoinViaExternalAppDialog {
+  constructor ({config, commandRegistry, workspace}) {
+    this.commandRegistry = commandRegistry
+    this.workspace = workspace
+    this.confirmOnce = this.confirmOnce.bind(this)
+    this.confirmAlways = this.confirmAlways.bind(this)
+    this.cancel = this.cancel.bind(this)
+    etch.initialize(this)
+    this.disposables = this.commandRegistry.add(this.element, 'core:cancel', this.cancel)
+  }
+
+  destroy() {
+    if (this.panel) this.panel.destroy()
+
+    this.disposables.dispose()
+    etch.destroy(this)
+  }
+
+  async show (uri) {
+    await this.update({uri})
+    this.panel = this.workspace.addModalPanel({item: this, visible: true, autoFocus: true})
+    this.element.focus()
+    this.element.addEventListener('blur', this.cancel)
+
+    return new Promise((resolve) => {
+      this.panel.onDidDestroy(() => {
+        this.panel = null
+        this.element.removeEventListener('blur', this.cancel)
+        resolve(this.exitStatus)
+      })
+    })
+  }
+
+  confirmOnce () {
+    this.exitStatus = this.constructor.EXIT_STATUS.CONFIRM_ONCE
+    this.panel.destroy()
+  }
+
+  confirmAlways () {
+    this.exitStatus = this.constructor.EXIT_STATUS.CONFIRM_ALWAYS
+    this.panel.destroy()
+  }
+
+  cancel () {
+    this.exitStatus = this.constructor.EXIT_STATUS.CANCEL
+    this.panel.destroy()
+  }
+
+  render () {
+    return $("div", {className: 'JoinViaExternalAppDialog', tabIndex: -1})
+  }
+
+  update (props) {
+    this.props = props
+    return etch.update(this)
+  }
+}
+
+module.exports.EXIT_STATUS = {
+  CONFIRM_ALWAYS: 0,
+  CONFIRM_ONCE: 1,
+  CANCEL: 2
+}

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -67,7 +67,7 @@ class JoinViaExternalAppDialog {
       $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar, and anything you type'),
       $.button(
         {
-          className: 'btn btn-primary selected',
+          className: 'btn btn-primary',
           onClick: this.confirmOnce
         },
         'Join portal'

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -1,6 +1,5 @@
 const etch = require('etch')
 const $ = etch.dom
-const {TextEditor} = require('atom')
 
 module.exports =
 class JoinViaExternalAppDialog {
@@ -14,7 +13,7 @@ class JoinViaExternalAppDialog {
     this.disposables = this.commandRegistry.add(this.element, 'core:cancel', this.cancel)
   }
 
-  destroy() {
+  destroy () {
     if (this.panel) this.panel.destroy()
 
     this.disposables.dispose()

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -86,7 +86,7 @@ class JoinViaExternalAppDialog {
             className: 'input-checkbox',
             type: 'checkbox'
           }),
-          $.span(null, 'Always join without asking. I only open portal URLs from people I trust.')
+          $.span(null, 'Always join without asking. I only open URLs from people I trust.')
         ),
         $.button(
           {className: 'btn btn-primary', onClick: this.confirm},

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -40,10 +40,10 @@ class JoinViaExternalAppDialog {
     this.element.addEventListener('blur', this.handleBlur)
 
     return new Promise((resolve) => {
+      this.resolveWithExitStatus = resolve
       this.panel.onDidDestroy(() => {
         this.panel = null
         this.element.removeEventListener('blur', this.handleBlur)
-        resolve(this.exitStatus)
       })
     })
   }
@@ -57,17 +57,17 @@ class JoinViaExternalAppDialog {
   }
 
   confirmOnce () {
-    this.exitStatus = this.constructor.EXIT_STATUS.CONFIRM_ONCE
+    this.resolveWithExitStatus(this.constructor.EXIT_STATUS.CONFIRM_ONCE)
     this.panel.destroy()
   }
 
   confirmAlways () {
-    this.exitStatus = this.constructor.EXIT_STATUS.CONFIRM_ALWAYS
+    this.resolveWithExitStatus(this.constructor.EXIT_STATUS.CONFIRM_ALWAYS)
     this.panel.destroy()
   }
 
   cancel () {
-    this.exitStatus = this.constructor.EXIT_STATUS.CANCEL
+    this.resolveWithExitStatus(this.constructor.EXIT_STATUS.CANCEL)
     this.panel.destroy()
   }
 

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -26,15 +26,16 @@ class JoinViaExternalAppDialog {
 
   async show (uri) {
     await this.update({uri})
-    // We explicitly add the modal as hidden because of a bug in the auto-focus
-    // feature that prevents it from working correctly when using visible: true.
-    this.panel = this.workspace.addModalPanel({item: this, visible: false, autoFocus: true})
-    this.panel.show()
 
     // This dialog could be opened before Atom's workaround for window focus is
     // triggered (see https://git.io/vxWDa), so we delay focusing it to prevent
     // such workaround from stealing focus from the dialog.
     await timeout(5)
+
+    // We explicitly add the modal as hidden because of a bug in the auto-focus
+    // feature that prevents it from working correctly when using visible: true.
+    this.panel = this.workspace.addModalPanel({item: this, visible: false, autoFocus: true})
+    this.panel.show()
     this.element.focus()
     this.element.addEventListener('blur', this.handleBlur)
 
@@ -71,7 +72,7 @@ class JoinViaExternalAppDialog {
   }
 
   render () {
-    if (this.props.uri == null) return $.div()
+    if (this.props.uri == null) return $.div() // discuss
 
     return $.div({className: 'JoinViaExternalAppDialog', tabIndex: -1},
       $.div(null,

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -9,6 +9,7 @@ class JoinViaExternalAppDialog {
     this.confirmOnce = this.confirmOnce.bind(this)
     this.confirmAlways = this.confirmAlways.bind(this)
     this.cancel = this.cancel.bind(this)
+    this.handleJoinButtonClick = this.handleJoinButtonClick.bind(this)
     this.handleBlur = this.handleBlur.bind(this)
     this.props = {}
     etch.initialize(this)
@@ -66,14 +67,16 @@ class JoinViaExternalAppDialog {
       $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar and anything you type.'),
       $.footer({className: 'JoinViaExternalAppDialog-footer'},
         $.label({className: 'input-label'},
-          $.input({className: 'input-checkbox', type: 'checkbox', checked: true}),
+          $.input({
+            ref: 'askBeforeJoiningCheckbox',
+            className: 'input-checkbox',
+            type: 'checkbox',
+            checked: true
+          }),
           $.span(null, 'Ask before joining a portal')
         ),
         $.button(
-          {
-            className: 'btn btn-primary',
-            onClick: this.confirmOnce
-          },
+          {className: 'btn btn-primary', onClick: this.handleJoinButtonClick},
           'Join portal'
         )
       )
@@ -83,6 +86,14 @@ class JoinViaExternalAppDialog {
   update (props) {
     this.props = props
     return etch.update(this)
+  }
+
+  handleJoinButtonClick () {
+    if (this.refs.askBeforeJoiningCheckbox.checked) {
+      this.confirmOnce()
+    } else {
+      this.confirmAlways()
+    }
   }
 
   handleBlur (event) {

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -102,6 +102,10 @@ class JoinViaExternalAppDialog {
     return etch.update(this)
   }
 
+  writeAfterUpdate () {
+    this.refs.askBeforeJoiningCheckbox.checked = true
+  }
+
   handleBlur (event) {
     if (document.hasFocus() && !this.element.contains(event.relatedTarget)) {
       this.cancel()

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -89,7 +89,7 @@ class JoinViaExternalAppDialog {
           $.span(null, 'Always join without asking. I only open URLs from people I trust.')
         ),
         $.button(
-          {className: 'btn btn-primary', onClick: this.confirm},
+          {className: 'btn btn-lg btn-primary', onClick: this.confirm},
           'Join portal'
         )
       )

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -30,8 +30,14 @@ class JoinViaExternalAppDialog {
     // feature that prevents it from working correctly when using visible: true.
     this.panel = this.workspace.addModalPanel({item: this, visible: false, autoFocus: true})
     this.panel.show()
+
+    // This dialog could be opened before Atom's workaround for window focus is
+    // triggered (see https://git.io/vxWDa), so we delay focusing it to prevent
+    // such workaround from stealing focus from the dialog.
+    await timeout(5)
     this.element.focus()
     this.element.addEventListener('blur', this.handleBlur)
+
     return new Promise((resolve) => {
       this.panel.onDidDestroy(() => {
         this.panel = null
@@ -108,4 +114,8 @@ module.exports.EXIT_STATUS = {
   CONFIRM_ALWAYS: 0,
   CONFIRM_ONCE: 1,
   CANCEL: 2
+}
+
+function timeout (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -61,10 +61,10 @@ class JoinViaExternalAppDialog {
     return $.div({className: 'JoinViaExternalAppDialog', tabIndex: -1},
       $.div(null,
         $.h1(null, 'Join this portal?'),
-        $.a({className: 'icon icon-x cancel', onClick: this.cancel})
+        $.a({className: 'JoinViaExternalAppDialog-cancel icon icon-x', onClick: this.cancel})
       ),
-      $.p(null, this.props.uri),
-      $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar, and anything you type'),
+      $.p({className: 'JoinViaExternalAppDialog-uri'}, this.props.uri),
+      $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar and anything you type.'),
       $.button(
         {
           className: 'btn btn-primary',

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -9,6 +9,7 @@ class JoinViaExternalAppDialog {
     this.confirmOnce = this.confirmOnce.bind(this)
     this.confirmAlways = this.confirmAlways.bind(this)
     this.cancel = this.cancel.bind(this)
+    this.handleBlur = this.handleBlur.bind(this)
     this.props = {}
     etch.initialize(this)
     this.disposables = this.commandRegistry.add(this.element, 'core:cancel', this.cancel)
@@ -25,16 +26,11 @@ class JoinViaExternalAppDialog {
     await this.update({uri})
     this.panel = this.workspace.addModalPanel({item: this, visible: true, autoFocus: true})
     this.element.focus()
-
-    // TODO Currently, this causes all buttons to trigger `this.cancel`. We need
-    // to figure out how to ensure that this only triggers when the user clicks
-    // outside of the modal without choosing one of the buttons.
-    // this.element.addEventListener('blur', this.cancel)
-
+    this.element.addEventListener('blur', this.handleBlur)
     return new Promise((resolve) => {
       this.panel.onDidDestroy(() => {
         this.panel = null
-        this.element.removeEventListener('blur', this.cancel)
+        this.element.removeEventListener('blur', this.handleBlur)
         resolve(this.exitStatus)
       })
     })
@@ -84,6 +80,12 @@ class JoinViaExternalAppDialog {
   update (props) {
     this.props = props
     return etch.update(this)
+  }
+
+  handleBlur (event) {
+    if (document.hasFocus() && !this.element.contains(event.relatedTarget)) {
+      this.cancel()
+    }
   }
 }
 

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -78,7 +78,7 @@ class JoinViaExternalAppDialog {
         $.a({className: 'JoinViaExternalAppDialog-cancel icon icon-x', onClick: this.cancel})
       ),
       $.p({className: 'JoinViaExternalAppDialog-uri'}, this.props.uri),
-      $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar and anything you type.'),
+      $.p(null, 'By joining this portal, the other collaborators will see your GitHub username, your avatar, and any edits that you perform inside the portal.'),
       $.footer({className: 'JoinViaExternalAppDialog-footer'},
         $.label({className: 'input-label'},
           $.input({

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -65,12 +65,18 @@ class JoinViaExternalAppDialog {
       ),
       $.p({className: 'JoinViaExternalAppDialog-uri'}, this.props.uri),
       $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar and anything you type.'),
-      $.button(
-        {
-          className: 'btn btn-primary',
-          onClick: this.confirmOnce
-        },
-        'Join portal'
+      $.footer({className: 'JoinViaExternalAppDialog-footer'},
+        $.label({className: 'input-label'},
+          $.input({className: 'input-checkbox', type: 'checkbox', checked: true}),
+          $.span(null, 'Ask before joining a portal')
+        ),
+        $.button(
+          {
+            className: 'btn btn-primary',
+            onClick: this.confirmOnce
+          },
+          'Join portal'
+        )
       )
     )
   }

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -9,7 +9,7 @@ class JoinViaExternalAppDialog {
     this.confirm = this.confirm.bind(this)
     this.cancel = this.cancel.bind(this)
     this.handleBlur = this.handleBlur.bind(this)
-    this.props = {}
+    this.props = {uri: ''}
     etch.initialize(this)
     this.disposables = this.commandRegistry.add(this.element, {
       'core:confirm': this.confirm,
@@ -72,8 +72,6 @@ class JoinViaExternalAppDialog {
   }
 
   render () {
-    if (this.props.uri == null) return $.div() // discuss
-
     return $.div({className: 'JoinViaExternalAppDialog', tabIndex: -1},
       $.div(null,
         $.h1(null, 'Join this portal?'),

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -24,7 +24,10 @@ class JoinViaExternalAppDialog {
 
   async show (uri) {
     await this.update({uri})
-    this.panel = this.workspace.addModalPanel({item: this, visible: true, autoFocus: true})
+    // We explicitly add the modal as hidden because of a bug in the auto-focus
+    // feature that prevents it from working correctly when using visible: true.
+    this.panel = this.workspace.addModalPanel({item: this, visible: false, autoFocus: true})
+    this.panel.show()
     this.element.focus()
     this.element.addEventListener('blur', this.handleBlur)
     return new Promise((resolve) => {

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -49,10 +49,10 @@ class JoinViaExternalAppDialog {
   }
 
   confirm () {
-    if (this.refs.askBeforeJoiningCheckbox.checked) {
-      this.confirmOnce()
-    } else {
+    if (this.refs.joinWithoutAskingCheckbox.checked) {
       this.confirmAlways()
+    } else {
+      this.confirmOnce()
     }
   }
 
@@ -82,12 +82,11 @@ class JoinViaExternalAppDialog {
       $.footer({className: 'JoinViaExternalAppDialog-footer'},
         $.label({className: 'input-label'},
           $.input({
-            ref: 'askBeforeJoiningCheckbox',
+            ref: 'joinWithoutAskingCheckbox',
             className: 'input-checkbox',
-            type: 'checkbox',
-            checked: true
+            type: 'checkbox'
           }),
-          $.span(null, 'Ask before joining a portal')
+          $.span(null, 'Always join without asking. I only open portal URLs from people I trust.')
         ),
         $.button(
           {className: 'btn btn-primary', onClick: this.confirm},
@@ -103,7 +102,7 @@ class JoinViaExternalAppDialog {
   }
 
   writeAfterUpdate () {
-    this.refs.askBeforeJoiningCheckbox.checked = true
+    this.refs.joinWithoutAskingCheckbox.checked = false
   }
 
   handleBlur (event) {

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -6,14 +6,15 @@ class JoinViaExternalAppDialog {
   constructor ({config, commandRegistry, workspace}) {
     this.commandRegistry = commandRegistry
     this.workspace = workspace
-    this.confirmOnce = this.confirmOnce.bind(this)
-    this.confirmAlways = this.confirmAlways.bind(this)
+    this.confirm = this.confirm.bind(this)
     this.cancel = this.cancel.bind(this)
-    this.handleJoinButtonClick = this.handleJoinButtonClick.bind(this)
     this.handleBlur = this.handleBlur.bind(this)
     this.props = {}
     etch.initialize(this)
-    this.disposables = this.commandRegistry.add(this.element, 'core:cancel', this.cancel)
+    this.disposables = this.commandRegistry.add(this.element, {
+      'core:confirm': this.confirm,
+      'core:cancel': this.cancel
+    })
   }
 
   destroy () {
@@ -38,6 +39,14 @@ class JoinViaExternalAppDialog {
         resolve(this.exitStatus)
       })
     })
+  }
+
+  confirm () {
+    if (this.refs.askBeforeJoiningCheckbox.checked) {
+      this.confirmOnce()
+    } else {
+      this.confirmAlways()
+    }
   }
 
   confirmOnce () {
@@ -76,7 +85,7 @@ class JoinViaExternalAppDialog {
           $.span(null, 'Ask before joining a portal')
         ),
         $.button(
-          {className: 'btn btn-primary', onClick: this.handleJoinButtonClick},
+          {className: 'btn btn-primary', onClick: this.confirm},
           'Join portal'
         )
       )
@@ -86,14 +95,6 @@ class JoinViaExternalAppDialog {
   update (props) {
     this.props = props
     return etch.update(this)
-  }
-
-  handleJoinButtonClick () {
-    if (this.refs.askBeforeJoiningCheckbox.checked) {
-      this.confirmOnce()
-    } else {
-      this.confirmAlways()
-    }
   }
 
   handleBlur (event) {

--- a/lib/join-via-external-app-dialog.js
+++ b/lib/join-via-external-app-dialog.js
@@ -9,6 +9,7 @@ class JoinViaExternalAppDialog {
     this.confirmOnce = this.confirmOnce.bind(this)
     this.confirmAlways = this.confirmAlways.bind(this)
     this.cancel = this.cancel.bind(this)
+    this.props = {}
     etch.initialize(this)
     this.disposables = this.commandRegistry.add(this.element, 'core:cancel', this.cancel)
   }
@@ -24,7 +25,11 @@ class JoinViaExternalAppDialog {
     await this.update({uri})
     this.panel = this.workspace.addModalPanel({item: this, visible: true, autoFocus: true})
     this.element.focus()
-    this.element.addEventListener('blur', this.cancel)
+
+    // TODO Currently, this causes all buttons to trigger `this.cancel`. We need
+    // to figure out how to ensure that this only triggers when the user clicks
+    // outside of the modal without choosing one of the buttons.
+    // this.element.addEventListener('blur', this.cancel)
 
     return new Promise((resolve) => {
       this.panel.onDidDestroy(() => {
@@ -51,7 +56,23 @@ class JoinViaExternalAppDialog {
   }
 
   render () {
-    return $("div", {className: 'JoinViaExternalAppDialog', tabIndex: -1})
+    if (this.props.uri == null) return $.div()
+
+    return $.div({className: 'JoinViaExternalAppDialog', tabIndex: -1},
+      $.div(null,
+        $.h1(null, 'Join this portal?'),
+        $.a({className: 'icon icon-x cancel', onClick: this.cancel})
+      ),
+      $.p(null, this.props.uri),
+      $.p(null, 'By joining this portal, other collaborators will be able to see your GitHub username, avatar, and anything you type'),
+      $.button(
+        {
+          className: 'btn btn-primary selected',
+          onClick: this.confirmOnce
+        },
+        'Join portal'
+      )
+    )
   }
 
   update (props) {

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -93,7 +93,7 @@ class TeletypePackage {
   async handleURI (parsedURI, rawURI) {
     const portalId = findPortalId(parsedURI.pathname) || rawURI
 
-    if (this.config.get('teletype.promptWhenJoiningPortalViaExternalApp')) {
+    if (this.config.get('teletype.askBeforeJoiningPortalViaExternalApp')) {
       const {EXIT_STATUS} = JoinViaExternalAppDialog
 
       const status = await this.joinViaExternalAppDialog.show(rawURI)
@@ -101,7 +101,7 @@ class TeletypePackage {
         case EXIT_STATUS.CONFIRM_ONCE:
           return this.joinPortal(portalId)
         case EXIT_STATUS.CONFIRM_ALWAYS:
-          this.config.set('teletype.promptWhenJoiningPortalViaExternalApp', false)
+          this.config.set('teletype.askBeforeJoiningPortalViaExternalApp', false)
           return this.joinPortal(portalId)
         default:
           break

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -6,17 +6,19 @@ const AuthenticationProvider = require('./authentication-provider')
 const CredentialCache = require('./credential-cache')
 const TeletypeService = require('./teletype-service')
 const {findPortalId} = require('./portal-id-helpers')
+const JoinViaExternalAppDialog = require('./join-via-external-app-dialog')
 
 module.exports =
 class TeletypePackage {
   constructor (options) {
     const {
-      baseURL, clipboard, commandRegistry, credentialCache, getAtomVersion,
+      baseURL, config, clipboard, commandRegistry, credentialCache, getAtomVersion,
       notificationManager, packageManager, peerConnectionTimeout, pubSubGateway,
       pusherKey, pusherOptions, tetherDisconnectWindow, tooltipManager,
       workspace
     } = options
 
+    this.config = config
     this.workspace = workspace
     this.notificationManager = notificationManager
     this.packageManager = packageManager
@@ -41,6 +43,7 @@ class TeletypePackage {
     })
     this.client.onConnectionError(this.handleConnectionError.bind(this))
     this.portalBindingManagerPromise = null
+    this.joinViaExternalAppDialog = new JoinViaExternalAppDialog({config, commandRegistry, workspace})
     this.subscriptions = new CompositeDisposable()
   }
 
@@ -87,9 +90,25 @@ class TeletypePackage {
     }
   }
 
-  handleURI (parsedURI, rawURI) {
+  async handleURI (parsedURI, rawURI) {
     const portalId = findPortalId(parsedURI.pathname) || rawURI
-    return this.joinPortal(portalId)
+
+    if (this.config.get('teletype.promptWhenJoiningPortalViaExternalApp')) {
+      const {EXIT_STATUS} = JoinViaExternalAppDialog
+
+      const status = await this.joinViaExternalAppDialog.show(rawURI)
+      switch (status) {
+        case EXIT_STATUS.CONFIRM_ONCE:
+          return this.joinPortal(portalId)
+        case EXIT_STATUS.CONFIRM_ALWAYS:
+          this.config.set('teletype.promptWhenJoiningPortalViaExternalApp', false)
+          return this.joinPortal(portalId)
+        default:
+          break
+      }
+    } else {
+      return this.joinPortal(portalId)
+    }
   }
 
   async sharePortal () {

--- a/package.json
+++ b/package.json
@@ -51,26 +51,33 @@
     "atom": ">=1.22.0"
   },
   "configSchema": {
+    "promptWhenJoiningPortalViaExternalApp": {
+      "title": "Prompt when joining a portal via external applications",
+      "description": "When set, you will be asked for confirmation every time you follow a portal URL in a third-party application.",
+      "type": "boolean",
+      "default": true,
+      "order": 1
+    },
     "baseURL": {
       "title": "API server base URL",
       "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
       "type": "string",
       "default": "https://api.teletype.atom.io",
-      "order": 1
+      "order": 2
     },
     "pusherKey": {
       "title": "Pusher service key",
       "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
       "type": "string",
       "default": "f119821248b7429bece3",
-      "order": 2
+      "order": 3
     },
     "pusherCluster": {
       "title": "Pusher cluster name",
       "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
       "type": "string",
       "default": "mt1",
-      "order": 3
+      "order": 4
     }
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "atom": ">=1.22.0"
   },
   "configSchema": {
-    "promptWhenJoiningPortalViaExternalApp": {
+    "askBeforeJoiningPortalViaExternalApp": {
       "title": "Ask before joining a portal via an external application",
       "description": "When set, you will be asked for confirmation every time you follow a portal URL in a third-party application.",
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "configSchema": {
     "promptWhenJoiningPortalViaExternalApp": {
-      "title": "Prompt when joining a portal via external applications",
+      "title": "Ask before joining a portal via an external application",
       "description": "When set, you will be asked for confirmation every time you follow a portal URL in a third-party application.",
       "type": "boolean",
       "default": true,

--- a/package.json
+++ b/package.json
@@ -58,26 +58,34 @@
       "default": true,
       "order": 1
     },
-    "baseURL": {
-      "title": "API server base URL",
-      "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
-      "type": "string",
-      "default": "https://api.teletype.atom.io",
-      "order": 2
-    },
-    "pusherKey": {
-      "title": "Pusher service key",
-      "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
-      "type": "string",
-      "default": "f119821248b7429bece3",
-      "order": 3
-    },
-    "pusherCluster": {
-      "title": "Pusher cluster name",
-      "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
-      "type": "string",
-      "default": "mt1",
-      "order": 4
+    "dev": {
+      "title": "Development Settings",
+      "collapsed": true,
+      "type": "object",
+      "order": 2,
+      "properties": {
+        "baseURL": {
+          "title": "API server base URL",
+          "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
+          "type": "string",
+          "default": "https://api.teletype.atom.io",
+          "order": 1
+        },
+        "pusherKey": {
+          "title": "Pusher service key",
+          "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
+          "type": "string",
+          "default": "f119821248b7429bece3",
+          "order": 2
+        },
+        "pusherCluster": {
+          "title": "Pusher cluster name",
+          "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
+          "type": "string",
+          "default": "mt1",
+          "order": 3
+        }
+      }
     }
   },
   "standard": {

--- a/styles/dialogs.less
+++ b/styles/dialogs.less
@@ -1,9 +1,0 @@
-@import "ui-variables";
-@import "octicon-mixins";
-
-
-// Shown when guest clicks on a portal URL
-
-.JoinViaExternalAppDialog {
-  padding: @component-padding;
-}

--- a/styles/dialogs.less
+++ b/styles/dialogs.less
@@ -1,0 +1,9 @@
+@import "ui-variables";
+@import "octicon-mixins";
+
+
+// Shown when guest clicks on a portal URL
+
+.JoinViaExternalAppDialog {
+  padding: @component-padding;
+}

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -254,6 +254,12 @@
     border-radius: @component-border-radius;
     background-color: @background-color-highlight;
   }
+
+  &-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 .JoinPortalComponent--no-prompt,

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -260,6 +260,16 @@
     align-items: center;
     justify-content: space-between;
   }
+
+  .input-label {
+    margin-left: 2em;
+    margin-right: 3em;
+  }
+
+  .input-checkbox {
+    margin-left: -2em;
+    margin-right: .5em;
+  }
 }
 
 .JoinPortalComponent--no-prompt,

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -233,6 +233,16 @@
   .octicon(mark-github, 40px);
 }
 
+.JoinViaExternalAppDialog {
+  h1 {
+    display: inline;
+  }
+
+  a.cancel {
+    float: right;
+  }
+}
+
 .JoinPortalComponent--no-prompt,
 .JoinPortalComponent--prompt
 {

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -234,12 +234,25 @@
 }
 
 .JoinViaExternalAppDialog {
-  h1 {
-    display: inline;
+  padding: @component-padding;
+
+  &-cancel {
+    position: absolute;
+    padding: @component-padding;
+    top: 0;
+    right: 0;
+    text-align: right;
+    &::before {
+      margin-right: 0;
+    }
   }
 
-  a.cancel {
-    float: right;
+  &-uri {
+    padding: @component-padding/2 @component-padding;
+    color: @text-color-highlight;
+    border: 1px solid @base-border-color;
+    border-radius: @component-border-radius;
+    background-color: @background-color-highlight;
   }
 }
 

--- a/test/helpers/atom-environments.js
+++ b/test/helpers/atom-environments.js
@@ -1,7 +1,7 @@
 const environments = []
 
 exports.buildAtomEnvironment = function buildAtomEnvironment () {
-  const env = global.buildAtomEnvironment()
+  const env = global.buildAtomEnvironment({enablePersistence: false})
   environments.push(env)
   return env
 }

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -117,7 +117,7 @@ suite('TeletypePackage', function () {
     test('opening URI for active portal', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
-      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const guestEnv = buildAtomEnvironment({askBeforeJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv)
 
       const hostPortal = await hostPackage.sharePortal()
@@ -130,7 +130,7 @@ suite('TeletypePackage', function () {
     })
 
     test('opening URI for nonexistent portal', async () => {
-      const env = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const env = buildAtomEnvironment({askBeforeJoiningPortalViaExternalApp: false})
       const pack = await buildPackage(env)
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
@@ -146,7 +146,7 @@ suite('TeletypePackage', function () {
       const hostPackage = await buildPackage(hostEnv)
 
       const TIMEOUT_IN_MILLISECONDS = 1
-      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const guestEnv = buildAtomEnvironment({askBeforeJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv, {peerConnectionTimeout: TIMEOUT_IN_MILLISECONDS})
       const notifications = []
       guestPackage.notificationManager.onDidAddNotification((n) => notifications.push(n))
@@ -161,7 +161,7 @@ suite('TeletypePackage', function () {
     })
 
     test('opening malformed URI', async () => {
-      const env = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const env = buildAtomEnvironment({askBeforeJoiningPortalViaExternalApp: false})
       const pack = await buildPackage(env)
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
@@ -179,7 +179,7 @@ suite('TeletypePackage', function () {
     test('opening URI when not signed in', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
-      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const guestEnv = buildAtomEnvironment({askBeforeJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv, {signIn: false})
 
       const hostPortal = await hostPackage.sharePortal()
@@ -1329,10 +1329,10 @@ suite('TeletypePackage', function () {
       env.config.set('teletype.' + key, setting.default)
     }
 
-    if (options.promptWhenJoiningPortalViaExternalApp !== undefined) {
+    if (options.askBeforeJoiningPortalViaExternalApp !== undefined) {
       env.config.set(
-        'teletype.promptWhenJoiningPortalViaExternalApp',
-        options.promptWhenJoiningPortalViaExternalApp
+        'teletype.askBeforeJoiningPortalViaExternalApp',
+        options.askBeforeJoiningPortalViaExternalApp
       )
     }
 

--- a/test/teletype-package.test.js
+++ b/test/teletype-package.test.js
@@ -2,7 +2,7 @@ const TeletypePackage = require('../lib/teletype-package')
 const {Errors} = require('@atom/teletype-client')
 const {TextBuffer, TextEditor} = require('atom')
 
-const {buildAtomEnvironment, destroyAtomEnvironments} = require('./helpers/atom-environments')
+const atomEnvironments = require('./helpers/atom-environments')
 const {loadPackageStyleSheets} = require('./helpers/ui-helpers')
 const assert = require('assert')
 const condition = require('./helpers/condition')
@@ -14,6 +14,7 @@ const fs = require('fs')
 const path = require('path')
 const temp = require('temp').track()
 const url = require('url')
+const {getPortalURI} = require('../lib/uri-helpers')
 
 suite('TeletypePackage', function () {
   this.timeout(process.env.TEST_TIMEOUT_IN_MS || 5000)
@@ -51,7 +52,7 @@ suite('TeletypePackage', function () {
     for (const pack of packages) {
       await pack.deactivate()
     }
-    await destroyAtomEnvironments()
+    await atomEnvironments.destroyAtomEnvironments()
   })
 
   test('sharing and joining a portal', async function () {
@@ -116,7 +117,7 @@ suite('TeletypePackage', function () {
     test('opening URI for active portal', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
-      const guestEnv = buildAtomEnvironment()
+      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv)
 
       const hostPortal = await hostPackage.sharePortal()
@@ -129,7 +130,8 @@ suite('TeletypePackage', function () {
     })
 
     test('opening URI for nonexistent portal', async () => {
-      const pack = await buildPackage(buildAtomEnvironment())
+      const env = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const pack = await buildPackage(env)
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
@@ -144,7 +146,7 @@ suite('TeletypePackage', function () {
       const hostPackage = await buildPackage(hostEnv)
 
       const TIMEOUT_IN_MILLISECONDS = 1
-      const guestEnv = buildAtomEnvironment()
+      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv, {peerConnectionTimeout: TIMEOUT_IN_MILLISECONDS})
       const notifications = []
       guestPackage.notificationManager.onDidAddNotification((n) => notifications.push(n))
@@ -159,7 +161,8 @@ suite('TeletypePackage', function () {
     })
 
     test('opening malformed URI', async () => {
-      const pack = await buildPackage(buildAtomEnvironment())
+      const env = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
+      const pack = await buildPackage(env)
       const notifications = []
       pack.notificationManager.onDidAddNotification((n) => notifications.push(n))
 
@@ -176,7 +179,7 @@ suite('TeletypePackage', function () {
     test('opening URI when not signed in', async () => {
       const hostEnv = buildAtomEnvironment()
       const hostPackage = await buildPackage(hostEnv)
-      const guestEnv = buildAtomEnvironment()
+      const guestEnv = buildAtomEnvironment({promptWhenJoiningPortalViaExternalApp: false})
       const guestPackage = await buildPackage(guestEnv, {signIn: false})
 
       const hostPortal = await hostPackage.sharePortal()
@@ -186,6 +189,63 @@ suite('TeletypePackage', function () {
       const guestPortal = await handleURI(guestPackage, uri)
       assert(!guestPortal)
       assert.equal(getRemotePaneItems(guestEnv).length, 0)
+    })
+
+    suite('prompting when opening URI', async () => {
+      test('canceling prompt', async () => {
+        const hostPackage = await buildPackage(buildAtomEnvironment())
+        const hostPortal = await hostPackage.sharePortal()
+        const guestEnv = buildAtomEnvironment()
+        const guestPackage = await buildPackage(guestEnv)
+
+        const guestPortalPromise = handleURI(guestPackage, getPortalURI(hostPortal.id))
+        await condition(() => guestEnv.workspace.getModalPanels().length === 1)
+        guestEnv.workspace.getModalPanels()[0].item.cancel()
+
+        assert(!await guestPortalPromise)
+        assert.equal(guestEnv.workspace.getModalPanels().length, 0)
+      })
+
+      test('allow joining once', async () => {
+        const hostPackage1 = await buildPackage(buildAtomEnvironment())
+        const hostPortal1 = await hostPackage1.sharePortal()
+        const hostPackage2 = await buildPackage(buildAtomEnvironment())
+        const hostPortal2 = await hostPackage2.sharePortal()
+        const guestEnv = buildAtomEnvironment()
+        const guestPackage = await buildPackage(guestEnv)
+
+        const guestPortal1Promise = handleURI(guestPackage, getPortalURI(hostPortal1.id))
+        await condition(() => guestEnv.workspace.getModalPanels().length === 1)
+        guestEnv.workspace.getModalPanels()[0].item.confirmOnce()
+
+        assert(await guestPortal1Promise)
+        assert.equal(guestEnv.workspace.getModalPanels().length, 0)
+
+        // Ensure dialog is shown again when joining another portal.
+        handleURI(guestPackage, getPortalURI(hostPortal2.id))
+        await condition(() => guestEnv.workspace.getModalPanels().length === 1)
+      })
+
+      test('allow joining always', async () => {
+        const hostPackage1 = await buildPackage(buildAtomEnvironment())
+        const hostPortal1 = await hostPackage1.sharePortal()
+        const hostPackage2 = await buildPackage(buildAtomEnvironment())
+        const hostPortal2 = await hostPackage2.sharePortal()
+        const guestEnv = buildAtomEnvironment()
+        const guestPackage = await buildPackage(guestEnv)
+
+        const guestPortal1Promise = handleURI(guestPackage, getPortalURI(hostPortal1.id))
+        await condition(() => guestEnv.workspace.getModalPanels().length === 1)
+        guestEnv.workspace.getModalPanels()[0].item.confirmAlways()
+
+        assert(await guestPortal1Promise)
+        assert.equal(guestEnv.workspace.getModalPanels().length, 0)
+
+        // Ensure dialog is NOT shown again when joining another portal.
+        const guestPortal2Promise = handleURI(guestPackage, getPortalURI(hostPortal2.id))
+        assert.equal(guestEnv.workspace.getModalPanels().length, 0)
+        assert(await guestPortal2Promise)
+      })
     })
   })
 
@@ -1260,6 +1320,25 @@ suite('TeletypePackage', function () {
     assert(description.includes('some error'))
   })
 
+  function buildAtomEnvironment (options = {}) {
+    const env = atomEnvironments.buildAtomEnvironment()
+
+    const {configSchema} = require('../package.json')
+    for (const key in configSchema) {
+      const setting = configSchema[key]
+      env.config.set('teletype.' + key, setting.default)
+    }
+
+    if (options.promptWhenJoiningPortalViaExternalApp !== undefined) {
+      env.config.set(
+        'teletype.promptWhenJoiningPortalViaExternalApp',
+        options.promptWhenJoiningPortalViaExternalApp
+      )
+    }
+
+    return env
+  }
+
   let nextTokenId = 0
   async function buildPackage (env, options = {}) {
     const credentialCache = new FakeCredentialCache()
@@ -1274,6 +1353,7 @@ suite('TeletypePackage', function () {
       getAtomVersion: function () { return 'x.y.z' },
       peerConnectionTimeout: options.peerConnectionTimeout,
       tetherDisconnectWindow: 300,
+      config: env.config,
       credentialCache
     })
     pack.registerRemoteEditorOpener()


### PR DESCRIPTION
Closes #109.

### Description of the Change

Building on the work in #346 and #348, this pull request implements the final item from the task list in https://github.com/atom/teletype/issues/109:

> - [ ] Ask the user to confirm before joining the portal [[motivation](https://github.com/atom/teletype/blob/e35483b1fa69c3ef1ef56f0c437000d4dcda934b/doc/rfcs/003-quickly-collaborate-with-coworkers-and-friends.md#join-a-portal-via-url)]

### TODO

- [x] Show modal dialog when user follows portal URL
- [x] Ask @simurai for help styling the dialog
- [x] Clicking outside of dialog should dismiss dialog without joining portal
- [x] `core:cancel` should dismiss dialog without joining portal
- [x] `core:confirm` should join the portal
- [x] In the settings UI, consider grouping the dev-specific options together (similar to the groupings used by the atom-ide package)
- [x] Wire up config option 
- [x] Consider alternative names and descriptions for the config option
- [x] Define and execute a verification process

### Verification Process

- [x] By default, following a URL asks before joining
- [x] Clicking outside of dialog dismisses dialog without joining portal
- [x] Clicking the 'x' dismisses dialog without joining portal
- [x] Hitting <kbd>esc</kbd> dismisses dialog without joining portal
- [x] Clicking "Join portal" joins portal
- [x] Hitting <kbd>return</kbd> joins portal
- [x] After enabling "join without asking" checkbox, following a URL automatically joins the portal
- [x] After re-enabling the "always ask" option in Teletype settings, following a URL asks before joining
- [x] After disabling the "always ask" option in Teletype settings, following a URL automatically joins the portal
- [x] Verify dialog renders properly in the most popular UI themes