### PR TITLE
Fix stacking of link icon

### DIFF
--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -384,13 +384,15 @@
       pointer-events: none;
 
       &::before {
-        z-index: 1;
+        position: relative;
+        z-index: 2;
       }
 
       // background cover
       &::after {
         content: "";
         position: absolute;
+        z-index: 1;
         left: -2px;
         top: 4px;
         width: 15px;


### PR DESCRIPTION
### Description of the Change

This PR tries to fix #345 by adding more `z-index`es.

### Alternate Designs

Use a separate element for the background.

### Benefits

Icon is not hidden

### Possible Drawbacks
None

### Verification Process

- [x] Join a portal.
- [x] Click on a user's avatar.
- [x] Link icon should be visible.

### Applicable Issues

Closes #345
