### PR TITLE
Return empty list of editors if PortalBinderManager is unavailable

### DIFF
--- a/lib/teletype-service.js
+++ b/lib/teletype-service.js
@@ -9,7 +9,7 @@ class TeletypeService {
     if (portalBindingManager) {
       return portalBindingManager.getRemoteEditors()
     } else {
-      return null
+      return []
     }
   }
 }

--- a/test/teletype-service.test.js
+++ b/test/teletype-service.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert')
+const TeletypeService = require('../lib/teletype-service')
+
+suite('TeletypeService', function () {
+  suite('getRemoteEditors()', function () {
+    test('returns an empty array when PortalBindingManager is unavailable', async () => {
+      const teletypePackage = {
+        getPortalBindingManager: () => {}
+      }
+      const service = new TeletypeService({teletypePackage})
+
+      assert.deepEqual(await service.getRemoteEditors(), [])
+    })
+  })
+})


### PR DESCRIPTION
https://github.com/atom/fuzzy-finder/pull/343 taught the fuzzy-finder package to gracefully handle the situation where the Teletype service is unable to fetch the list of remote editors. But instead of requiring all consumers of the service to deal with this scenario, this pull request updates the service to return an empty array (instead of `null`) if the Teletype service is unable to fetch the list of remote editors.
