### PR TITLE
Fix clicking on lines next to the avatars

### DIFF
--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -401,6 +401,7 @@
   right: @corner-margin;
   bottom: @corner-margin;
   overflow: hidden;
+  pointer-events: none;
 
   img {
     cursor: pointer;
@@ -410,6 +411,7 @@
 
   .SitePositionsComponent-site {
     margin-left: @avatar-margin;
+    pointer-events: auto;
 
     &.viewing-non-portal-item {
       opacity: 0.5;


### PR DESCRIPTION
### Description of the Change

This turns off pointer events on `SitePositionsComponent` and enables them again on each avatar.

### Benefits

User can click through to lines underneath.

### Possible Drawbacks

None

### Verification Process

1. Clicking on lines next to the avatars is possible.
2. Clicking on avatars is possible.

![teletype](https://user-images.githubusercontent.com/378023/38720928-11a77962-3f33-11e8-9625-5b354b29baff.gif)

### Applicable Issues

Fixes #362
