### PR TITLE
Add border around avatar to identify their cursor color

### DIFF
--- a/lib/site-positions-component.js
+++ b/lib/site-positions-component.js
@@ -1,6 +1,7 @@
 const etch = require('etch')
 const $ = etch.dom
 const getAvatarURL = require('./get-avatar-url')
+const {FollowState} = require('@atom/teletype-client')
 
 module.exports =
 class SitePositionsComponent {
@@ -43,12 +44,13 @@ class SitePositionsComponent {
     const {portal} = this.props
 
     const {login} = portal.getSiteIdentity(siteId)
+    const color = this.isCursorVisibleForSite(siteId) ? `color--site-${siteId}` : ''
     const location = this.getLocationForSite(siteId)
     const onClick = (location === 'viewing-non-portal-item')
       ? () => {}
       : () => this.onSelectSiteId(siteId)
 
-    return $.div({className: `SitePositionsComponent-site site-${siteId} ${location}`},
+    return $.div({className: `SitePositionsComponent-site site-${siteId} ${location} ${color}`},
       (portal.getFollowedSiteId() === siteId) ? $.div({className: 'icon icon-link'}) : null,
       $.img({
         src: getAvatarURL(login, 80),
@@ -63,6 +65,13 @@ class SitePositionsComponent {
     } else {
       this.props.portal.follow(siteId)
     }
+  }
+
+  // Private
+  isCursorVisibleForSite (siteId) {
+    const followState = this.props.positionsBySiteId[siteId].followState
+    return this.getLocationForSite(siteId) === 'viewing-current-editor' &&
+      (followState === FollowState.DISCONNECTED || followState === FollowState.EXTENDED)
   }
 
   // Private

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "^0.37.2",
+    "@atom/teletype-client": "git+https://github.com/atom/teletype-client#include-follow-state-in-active-positions",
     "etch": "^0.12.6"
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "git+https://github.com/atom/teletype-client#include-follow-state-in-active-positions",
+    "@atom/teletype-client": "0.38.0",
     "etch": "^0.12.6"
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "temp": "^0.8.3"
   },
   "dependencies": {
-    "@atom/teletype-client": "0.38.0",
+    "@atom/teletype-client": "^0.38.0",
     "etch": "^0.12.6"
   },
   "providedServices": {

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -485,8 +485,8 @@
 
     .icon-link {
       position: absolute;
-      margin-left: 24px;
-      margin-top: 24px;
+      margin-left: 26px;
+      margin-top: 26px;
       color: @text-color-info;
       pointer-events: none;
 

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -406,12 +406,78 @@
   img {
     cursor: pointer;
     height: @avatar-size;
+    border: 2px solid transparent;
     border-radius: 50%
   }
 
   .SitePositionsComponent-site {
     margin-left: @avatar-margin;
     pointer-events: auto;
+    border: solid 2px transparent;
+    border-radius: 50%;
+
+    // TODO Refactor to eliminiate duplication between this and cursor.ParticipantCursor
+    &.color {
+      &--site-1 {
+        border-color: @ui-site-color-1;
+      }
+
+      &--site-2 {
+        border-color: @ui-site-color-2;
+      }
+
+      &--site-3 {
+        border-color: @ui-site-color-3;
+      }
+
+      &--site-4 {
+        border-color: @ui-site-color-4;
+      }
+
+      &--site-5 {
+        border-color: @ui-site-color-5;
+      }
+
+      &--site-6 {
+        border-color: spin(@ui-site-color-1, 25);
+      }
+
+      &--site-7 {
+        border-color: spin(@ui-site-color-2, 25);
+      }
+
+      &--site-8 {
+        border-color: spin(@ui-site-color-3, 25);
+      }
+
+      &--site-9 {
+        border-color: spin(@ui-site-color-4, 25);
+      }
+
+      &--site-10 {
+        border-color: spin(@ui-site-color-5, 25);
+      }
+
+      &--site-11 {
+        border-color: spin(@ui-site-color-1, 65);
+      }
+
+      &--site-12 {
+        border-color: spin(@ui-site-color-2, 65);
+      }
+
+      &--site-13 {
+        border-color: spin(@ui-site-color-3, 65);
+      }
+
+      &--site-14 {
+        border-color: spin(@ui-site-color-4, 65);
+      }
+
+      &--site-15 {
+        border-color: spin(@ui-site-color-5, 65);
+      }
+    }
 
     &.viewing-non-portal-item {
       opacity: 0.5;

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -324,68 +324,6 @@
   opacity: 1;
 }
 
-.cursor.ParticipantCursor {
-  &--site-1 {
-    border-left-color: @ui-site-color-1;
-  }
-
-  &--site-2 {
-    border-left-color: @ui-site-color-2;
-  }
-
-  &--site-3 {
-    border-left-color: @ui-site-color-3;
-  }
-
-  &--site-4 {
-    border-left-color: @ui-site-color-4;
-  }
-
-  &--site-5 {
-    border-left-color: @ui-site-color-5;
-  }
-
-  &--site-6 {
-    border-left-color: spin(@ui-site-color-1, 25);
-  }
-
-  &--site-7 {
-    border-left-color: spin(@ui-site-color-2, 25);
-  }
-
-  &--site-8 {
-    border-left-color: spin(@ui-site-color-3, 25);
-  }
-
-  &--site-9 {
-    border-left-color: spin(@ui-site-color-4, 25);
-  }
-
-  &--site-10 {
-    border-left-color: spin(@ui-site-color-5, 25);
-  }
-
-  &--site-11 {
-    border-left-color: spin(@ui-site-color-1, 65);
-  }
-
-  &--site-12 {
-    border-left-color: spin(@ui-site-color-2, 65);
-  }
-
-  &--site-13 {
-    border-left-color: spin(@ui-site-color-3, 65);
-  }
-
-  &--site-14 {
-    border-left-color: spin(@ui-site-color-4, 65);
-  }
-
-  &--site-15 {
-    border-left-color: spin(@ui-site-color-5, 65);
-  }
-}
-
 .SitePositionsComponent {
   @corner-margin: @component-padding * 1.5;
   @avatar-margin: @component-padding / 2;
@@ -415,69 +353,6 @@
     pointer-events: auto;
     border: solid 2px transparent;
     border-radius: 50%;
-
-    // TODO Refactor to eliminiate duplication between this and cursor.ParticipantCursor
-    &.color {
-      &--site-1 {
-        border-color: @ui-site-color-1;
-      }
-
-      &--site-2 {
-        border-color: @ui-site-color-2;
-      }
-
-      &--site-3 {
-        border-color: @ui-site-color-3;
-      }
-
-      &--site-4 {
-        border-color: @ui-site-color-4;
-      }
-
-      &--site-5 {
-        border-color: @ui-site-color-5;
-      }
-
-      &--site-6 {
-        border-color: spin(@ui-site-color-1, 25);
-      }
-
-      &--site-7 {
-        border-color: spin(@ui-site-color-2, 25);
-      }
-
-      &--site-8 {
-        border-color: spin(@ui-site-color-3, 25);
-      }
-
-      &--site-9 {
-        border-color: spin(@ui-site-color-4, 25);
-      }
-
-      &--site-10 {
-        border-color: spin(@ui-site-color-5, 25);
-      }
-
-      &--site-11 {
-        border-color: spin(@ui-site-color-1, 65);
-      }
-
-      &--site-12 {
-        border-color: spin(@ui-site-color-2, 65);
-      }
-
-      &--site-13 {
-        border-color: spin(@ui-site-color-3, 65);
-      }
-
-      &--site-14 {
-        border-color: spin(@ui-site-color-4, 65);
-      }
-
-      &--site-15 {
-        border-color: spin(@ui-site-color-5, 65);
-      }
-    }
 
     &.viewing-non-portal-item {
       opacity: 0.5;
@@ -509,6 +384,26 @@
       }
     }
   }
+}
+
+// Site colors
+.cursor.ParticipantCursor, // cursor
+.SitePositionsComponent-site.color  { // avatar
+  &--site-1  { border-color: @ui-site-color-1; }
+  &--site-2  { border-color: @ui-site-color-2; }
+  &--site-3  { border-color: @ui-site-color-3; }
+  &--site-4  { border-color: @ui-site-color-4; }
+  &--site-5  { border-color: @ui-site-color-5; }
+  &--site-6  { border-color: spin(@ui-site-color-1, 25); }
+  &--site-7  { border-color: spin(@ui-site-color-2, 25); }
+  &--site-8  { border-color: spin(@ui-site-color-3, 25); }
+  &--site-9  { border-color: spin(@ui-site-color-4, 25); }
+  &--site-10 { border-color: spin(@ui-site-color-5, 25); }
+  &--site-11 { border-color: spin(@ui-site-color-1, 65); }
+  &--site-12 { border-color: spin(@ui-site-color-2, 65); }
+  &--site-13 { border-color: spin(@ui-site-color-3, 65); }
+  &--site-14 { border-color: spin(@ui-site-color-4, 65); }
+  &--site-15 { border-color: spin(@ui-site-color-5, 65); }
 }
 
 .PackageOutdatedComponent, .PackageInitializationErrorComponent {

--- a/test/site-positions-component.test.js
+++ b/test/site-positions-component.test.js
@@ -7,6 +7,7 @@ const SAMPLE_TEXT = fs.readFileSync(path.join(__dirname, 'fixtures', 'sample.js'
 const FakePortal = require('./helpers/fake-portal')
 const FakeEditorProxy = require('./helpers/fake-editor-proxy')
 const SitePositionsComponent = require('../lib/site-positions-component')
+const {FollowState} = require('@atom/teletype-client')
 
 suite('SitePositionsComponent', () => {
   teardown(async () => {
@@ -49,17 +50,32 @@ suite('SitePositionsComponent', () => {
     await workspace.open(editor1)
 
     const positionsBySiteId = {
-      1: {editorProxy: editorProxy1, position: {row: 0, column: 0}}, // the local user
-      2: {editorProxy: editorProxy1, position: {row: 0, column: 0}}, // a collaborator in the same editor
-      3: {editorProxy: editorProxy2, position: {row: 0, column: 0}}, // a collaborator in a different editor
-      4: {editorProxy: null, position: null} // a collaborator in a non-portal pane item
+      // the local user
+      1: {editorProxy: editorProxy1, position: {row: 0, column: 0}, followState: FollowState.DISCONNECTED},
+
+      // a collaborator in the same editor, with a disconnected tether
+      2: {editorProxy: editorProxy1, position: {row: 0, column: 0}, followState: FollowState.DISCONNECTED},
+
+      // a collaborator in the same editor, with an extended tether
+      3: {editorProxy: editorProxy1, position: {row: 0, column: 0}, followState: FollowState.EXTENDED},
+
+      // a collaborator in the same editor, with a retracted tether
+      4: {editorProxy: editorProxy1, position: {row: 0, column: 0}, followState: FollowState.RETRACTED},
+
+      // a collaborator in a different editor
+      5: {editorProxy: editorProxy2, position: {row: 0, column: 0}, followState: FollowState.DISCONNECTED},
+
+      // a collaborator in a non-portal pane item
+      6: {editorProxy: null, position: null, followState: null}
     }
     await component.update({positionsBySiteId})
 
     assert(!element.querySelector('.SitePositionsComponent-site.site-1'))
-    assert(element.querySelector('.SitePositionsComponent-site.site-2.viewing-current-editor'))
-    assert(element.querySelector('.SitePositionsComponent-site.site-3.viewing-other-editor'))
-    assert(element.querySelector('.SitePositionsComponent-site.site-4.viewing-non-portal-item'))
+    assert(element.querySelector('.SitePositionsComponent-site.site-2.viewing-current-editor.color--site-2'))
+    assert(element.querySelector('.SitePositionsComponent-site.site-3.viewing-current-editor.color--site-3'))
+    assert(element.querySelector('.SitePositionsComponent-site.site-4.viewing-current-editor:not(.color--site-4)'))
+    assert(element.querySelector('.SitePositionsComponent-site.site-5.viewing-other-editor:not(.color--site-5)'))
+    assert(element.querySelector('.SitePositionsComponent-site.site-6.viewing-non-portal-item:not(.color--site-6)'))
   })
 
   test('following and unfollowing a site', () => {

--- a/test/site-positions-component.test.js
+++ b/test/site-positions-component.test.js
@@ -60,6 +60,12 @@ suite('SitePositionsComponent', () => {
     assert(element.querySelector('.SitePositionsComponent-site.site-2.viewing-current-editor'))
     assert(element.querySelector('.SitePositionsComponent-site.site-3.viewing-other-editor'))
     assert(element.querySelector('.SitePositionsComponent-site.site-4.viewing-non-portal-item'))
+  })
+
+  test('following and unfollowing a site', () => {
+    const {workspace} = buildAtomEnvironment()
+    const portal = new FakePortal({siteId: 1})
+    const component = new SitePositionsComponent({workspace, portal})
 
     // Selecting a site will follow them.
     component.onSelectSiteId(42)


### PR DESCRIPTION
Closes #338

Depends on https://github.com/atom/teletype-client/pull/61

---

### Description of the Change

This pull request implements the design shown in https://github.com/atom/teletype/issues/338#issuecomment-371802426.

In the screenshot below, we see the addition of colored borders around some avatars. When a participant's cursor appears in the current editor, the avatar will now have a border with a color that matches the user's cursor color.

![screenshot](https://user-images.githubusercontent.com/2988/38900407-57e6ec12-4269-11e8-8b81-8e0252549fd3.png)

### Verification Process

- [x] Border shown when another collaborator is typing in the same editor
- [x] Border not shown when another collaborator is typing in a different editor
- [x] Border appears again when collaborator navigates to the editor you're currently viewing and begins typing or selecting
- [x] Border not shown when another collaborator is viewing a non-portal item (e.g., the settings view)
- [x] Border not shown when another collaborator has a retracted tether
- [x] Up to 15 sites can have unique cursor colors

### TODO

- [x] Implement preliminary functionality
- [x] Reduce duplication in CSS re: site colors (e.g., [cursor color for site 6](https://github.com/atom/teletype/blob/a6c293a5fd57987d095f3260b65c730b7519ec84/styles/teletype.less#L348-L350) vs. [avatar border color for site 6](https://github.com/atom/teletype/blob/a6c293a5fd57987d095f3260b65c730b7519ec84/styles/teletype.less#L441-L443))
- [x] Update [tests](https://github.com/atom/teletype/blob/a1f6eeaf102c57236008e383c8e5ba7b225fd06b/test/site-positions-component.test.js#L36-L71) to exercise this new behavior
- [x] Define and execute verification process
