### PR TITLE
RFE: remove pusher.com dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = new TeletypePackage({
   commandRegistry: atom.commands,
   tooltipManager: atom.tooltips,
   clipboard: atom.clipboard,
+  activePubSubGateway: atom.config.get('teletype.dev.activePubSubGateway'),
   pusherKey: atom.config.get('teletype.dev.pusherKey'),
   pusherOptions: {
     cluster: atom.config.get('teletype.dev.pusherCluster'),

--- a/lib/teletype-package.js
+++ b/lib/teletype-package.js
@@ -14,7 +14,7 @@ class TeletypePackage {
     const {
       baseURL, config, clipboard, commandRegistry, credentialCache, getAtomVersion,
       notificationManager, packageManager, peerConnectionTimeout, pubSubGateway,
-      pusherKey, pusherOptions, tetherDisconnectWindow, tooltipManager,
+      activePubSubGateway, pusherKey, pusherOptions, tetherDisconnectWindow, tooltipManager,
       workspace
     } = options
 
@@ -26,6 +26,7 @@ class TeletypePackage {
     this.tooltipManager = tooltipManager
     this.clipboard = clipboard
     this.pubSubGateway = pubSubGateway
+    this.activePubSubGateway = activePubSubGateway
     this.pusherKey = pusherKey
     this.pusherOptions = pusherOptions
     this.baseURL = baseURL
@@ -34,6 +35,7 @@ class TeletypePackage {
     this.tetherDisconnectWindow = tetherDisconnectWindow
     this.credentialCache = credentialCache || new CredentialCache()
     this.client = new TeletypeClient({
+      activePubSubGateway: this.activePubSubGateway,
       pusherKey: this.pusherKey,
       pusherOptions: this.pusherOptions,
       baseURL: this.baseURL,
@@ -48,6 +50,7 @@ class TeletypePackage {
   }
 
   activate () {
+    console.log('teletype: Using pubsub gateway:', this.activePubSubGateway)
     console.log('teletype: Using pusher key:', this.pusherKey)
     console.log('teletype: Using base URL:', this.baseURL)
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,13 @@
           "type": "string",
           "default": "mt1",
           "order": 3
+        },
+        "activePubSubGateway": {
+          "title": "The pubSubGateway that should be used for teletype (pusher or socketcluster)",
+          "description": "This should only be changed for development purposes. Changes take effect on the next package activation.",
+          "type": "string",
+          "default": "pusher",
+          "order": 4
         }
       }
     }


### PR DESCRIPTION
**Please be sure to read the [contributor's guide](https://github.com/atom/teletype/blob/master/CONTRIBUTING.md) before submitting any pull        requests.**

### Requirements
* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed  at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

Updated teletype-server to use different external dependencies.  Replaced Twilio with Coturn and Pusher with SocketCluster.

### Alternate Designs
SocketCluster could be replaced with a separate library that handles pubSub.

### Benefits

It is possible to run teletype-server without having to use external dependencies.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Ran teletype-server with coturn and socketcluster and verified that atom could establish a shared session.

### Applicable Issues

https://github.com/atom/teletype-server/issues/35