### PR TITLE
[do not merge] Test CI against atom/ci changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - createdb teletype-test
 
 script:
-  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/aw/npm-up/build-package.sh
   - chmod u+x build-package.sh
   - ./build-package.sh
 


### PR DESCRIPTION
Ensure that the changes in atom/ci#86:

* Do not break the stable and beta channel builds in Travis (which are using the older npm version)
* Fix the dev channel build in Travis (which is using the newer npm version)