### PR TITLE
Add setting to hide collaborators in text editor

### DIFF
--- a/lib/guest-portal-binding.js
+++ b/lib/guest-portal-binding.js
@@ -243,7 +243,7 @@ class GuestPortalBinding {
   didChangeActivePaneItem (paneItem) {
     const editorProxy = this.editorProxiesByEditor.get(paneItem)
 
-    if (editorProxy) {
+    if (editorProxy && atom.config.get('teletype.displayCollaboratorsOnScreen')) {
       this.sitePositionsComponent.show(paneItem.element)
     } else {
       this.sitePositionsComponent.hide()

--- a/lib/host-portal-binding.js
+++ b/lib/host-portal-binding.js
@@ -31,9 +31,13 @@ class HostPortalBinding {
       this.portal.setDelegate(this)
       this.disposables.add(
         this.workspace.observeTextEditors(this.didAddTextEditor.bind(this)),
-        this.workspace.observeActiveTextEditor(this.didChangeActiveTextEditor.bind(this))
-      )
+        this.workspace.observeActiveTextEditor(this.didChangeActiveTextEditor.bind(this)),
 
+        atom.config.observe('teletype.displayCollaboratorsOnScreen', (value) => {
+          console.log("change observed "+ value)
+          this.didChangeActiveTextEditor(this.workspace.getActiveTextEditor())
+        })
+      )
       this.workspace.getElement().classList.add('teletype-Host')
       return true
     } catch (error) {
@@ -76,7 +80,10 @@ class HostPortalBinding {
     if (editor && !editor.isRemote) {
       const editorProxy = this.findOrCreateEditorProxyForEditor(editor)
       this.portal.activateEditorProxy(editorProxy)
-      this.sitePositionsComponent.show(editor.element)
+
+      if (atom.config.get('teletype.displayCollaboratorsOnScreen')) {
+        this.sitePositionsComponent.show(editor.element)
+      }
     } else {
       this.portal.activateEditorProxy(null)
       this.sitePositionsComponent.hide()

--- a/package.json
+++ b/package.json
@@ -58,11 +58,18 @@
       "default": true,
       "order": 1
     },
+    "displayCollaboratorsOnScreen": {
+      "title": "Display collaborators on the text editor",
+      "description": "When set, you will be able to see your collaborators on the text editor lower-right corner.",
+      "type": "boolean",
+      "default": true,
+      "order": 2
+    },
     "dev": {
       "title": "Development Settings",
       "collapsed": true,
       "type": "object",
-      "order": 2,
+      "order": 3,
       "properties": {
         "baseURL": {
           "title": "API server base URL",


### PR DESCRIPTION
### Description of the Change

The package's settings page now has a new boolean allowing to display or hide the collaborators avatars in the text editor.

### Alternate Designs

This change is the most simple one. Putting this option as a setting does not overload the user interface. I considered adding it as a menu item but I don't think it is an option used enough to be displayed as such.

### Benefits

As seen in the poll, most people use teletype with only few participants. My collaborators and I mostly work in group of two or three and in the same workspace. Our utilisation of the package does not require any knowledge of each user's position. We often use the plugin during meeting to take collaborative notes on half a laptop's screen. The reduced window size puts the avatars over the code, and the blinking colors around the avatars is distracting. Allowing it to simply hide those avatar solves all these problems.

### Possible Drawbacks

I don't see any.

### Verification Process

I followed the official contribution guide. After implementing this feature I ran the tests (but did not add any) wich still passed. I ran local manual tests to check the correct behaviour and display of the avatars.
