### PR TITLE
Add libdbus-1-3 dependency for Electron 3 builds of Atom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
     - secure: om1VFZYOtLRBOHh3+UDms24wIoRsBu73jMrvNoI2/ThElkihHnD6LbdI1qkPEOkufgMlSjTzQml0VqJgN4gACHfB3Y/cx2k0ThUs7H8Zjv7h90xeegMrj5yA+m2ahqln6rZxtSfog/3owYi9m75iZlXKbl72oXBhCrQMcZ4/BIktdLhR8loEZrYoFgxTOxt6kQwHu67WGmtaRdZcp11ve8ToWqp/Wm1IWGRjeNe5C3dHevS4xsUTRK+hoIov1/nwYysQ8RgmxgJGwzwtCjNkwyqwWku9M0ACVqdqXlFYmcNNWWj2e9buVP9mkX9KHVhPaA72CtgPgO1cvV6HFeA4npn/UKHi+FsMfeGBUkUYP+sQ/CauiSq0LW2zoQIlzsFr5GNI5l2kMhQ9cKoA0CMPwfAjK2rRLLx9c61vNjFqVJtL3KiaYsgPnss8CWprvPgCUjWwbPknjY899EVxhP0bcSt1Nyh0XkzFSCFTWGMWwz/u31w3CVOWE0ez1OdjW4is7EmKhH08Zkt46e/Rr5qZFobc9RM1JYhW67rFPvged4eCz0opxrjci2RcYMh/vV+JJF3NYcpxkEI3dRLB1xpQDL0PtEsuvTSIjCRZYcc4RYb+4NDp7vIgMf20Gt+kTwYs30KyCVMTNmWa7x04pClbo/0BN9Q58ZJT8PsCb62W/N4=
 
 install:
-  - sudo apt-get --only-upgrade install libnss3
+  - sudo apt-get --only-upgrade install libnss3 libdbus-1-3
 
 addons:
   apt:


### PR DESCRIPTION
### Description of the Change

Latest Teletype master builds on Travis CI against Atom Dev are failing with a renderer crash.  One obvious starting point is this error that gets written out in the `dev` build log:

```
/home/travis/atom/usr/share/atom-dev/atom: /lib/x86_64-linux-gnu/libdbus-1.so.3: no version information available (required by /home/travis/atom/usr/share/atom-dev/atom)
```

This change adds `libdbus-1-3` to the `apt-get install` call to ensure that this dependency exists on the CI machine.

### Alternate Designs

None at the moment, let's see if this fixes the issue.

### Benefits

Passing `dev` builds on `master`.

### Possible Drawbacks

None.

### Verification Process

- [x] Verified that no renderer process crash occurs locally on my Linux dev machine
- [ ] Green CI build after adding the new dependency

### Applicable Issues

None.
