### PR TITLE
Fix tests that run against Atom dev channel by upgrading to Ubuntu 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: '7'
 sudo: false
 os: linux
-dist: trusty
+dist: xenial
 
 env:
   matrix:
@@ -20,6 +20,7 @@ notifications:
     - secure: om1VFZYOtLRBOHh3+UDms24wIoRsBu73jMrvNoI2/ThElkihHnD6LbdI1qkPEOkufgMlSjTzQml0VqJgN4gACHfB3Y/cx2k0ThUs7H8Zjv7h90xeegMrj5yA+m2ahqln6rZxtSfog/3owYi9m75iZlXKbl72oXBhCrQMcZ4/BIktdLhR8loEZrYoFgxTOxt6kQwHu67WGmtaRdZcp11ve8ToWqp/Wm1IWGRjeNe5C3dHevS4xsUTRK+hoIov1/nwYysQ8RgmxgJGwzwtCjNkwyqwWku9M0ACVqdqXlFYmcNNWWj2e9buVP9mkX9KHVhPaA72CtgPgO1cvV6HFeA4npn/UKHi+FsMfeGBUkUYP+sQ/CauiSq0LW2zoQIlzsFr5GNI5l2kMhQ9cKoA0CMPwfAjK2rRLLx9c61vNjFqVJtL3KiaYsgPnss8CWprvPgCUjWwbPknjY899EVxhP0bcSt1Nyh0XkzFSCFTWGMWwz/u31w3CVOWE0ez1OdjW4is7EmKhH08Zkt46e/Rr5qZFobc9RM1JYhW67rFPvged4eCz0opxrjci2RcYMh/vV+JJF3NYcpxkEI3dRLB1xpQDL0PtEsuvTSIjCRZYcc4RYb+4NDp7vIgMf20Gt+kTwYs30KyCVMTNmWa7x04pClbo/0BN9Q58ZJT8PsCb62W/N4=
 
 install:
+  - sudo apt -y install libgconf2-4 # TODO: Remove once Atom 1.39 is stable
   - sudo apt-get --only-upgrade install libnss3
 
 addons:


### PR DESCRIPTION
Refs https://github.com/atom/ci/issues/93

We recently [switched from Travis to Azure Pipelines for our Atom Linux artifacts](https://github.com/atom/atom/pull/19597), and as an unexpected consequence, package builds that rely on Atom started failing with the following error installing the Atom package:

```
Downloading latest Atom release on the dev channel...
dpkg-deb: error: archive 'atom-amd64.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
```

On Travis, we were building Atom on Ubuntu 14. On Azure Pipelines, we're using Ubuntu 16, and it seems that packages built on Ubuntu 16 trigger this error on Ubuntu 14, which is the version currently used on our package builds as well. Seeing as how Ubuntu 14 has reached "end of standard support", I think it makes sense to upgrade our packages to run on newer versions rather than try to move backwards with our main Atom build.

It seems that Atom 1.38 (which runs on Electron 2.x) needs an additional dependency to be installed which isn't available on the Ubuntu 16 image. Versions of Atom greater than 1.38 seem to build fine without that dependency, so I've added a comment on the dependency so we can remove it in the future.