### PR TITLE
Add avatars below cursors

### DIFF
--- a/lib/editor-binding.js
+++ b/lib/editor-binding.js
@@ -4,6 +4,7 @@ const path = require('path')
 const {Range, Emitter, Disposable, CompositeDisposable, TextBuffer} = require('atom')
 const {getEditorURI} = require('./uri-helpers')
 const {FollowState} = require('@atom/teletype-client')
+const getAvatarURL = require('./get-avatar-url')
 
 module.exports =
 class EditorBinding {
@@ -148,6 +149,15 @@ class EditorBinding {
       markerLayer = this.editor.addMarkerLayer()
       this.editor.decorateMarkerLayer(markerLayer, {type: 'cursor', class: cursorClassForSiteId(siteId, {blink: false})})
       this.editor.decorateMarkerLayer(markerLayer, {type: 'highlight', class: 'selection'})
+
+      const {login} = this.portal.getSiteIdentity(siteId)
+      const overlayElement = document.createElement('div')
+      overlayElement.className = `avatar-below-cursor-site color--site-${siteId}`
+      const overlayImageElement = document.createElement('img')
+      overlayImageElement.src = getAvatarURL(login, 40),
+      overlayElement.appendChild(overlayImageElement)
+      this.editor.decorateMarkerLayer(markerLayer, {type: 'overlay', class: 'avatar-below-cursor', item: overlayElement})
+
       this.markerLayersBySiteId.set(siteId, markerLayer)
     }
 

--- a/styles/teletype.less
+++ b/styles/teletype.less
@@ -386,9 +386,26 @@
   }
 }
 
+.avatar-below-cursor {
+  pointer-events: none;
+
+  img {
+    height: 44px;
+    border: 2px solid transparent;
+    border-radius: 50%
+  }
+
+  .avatar-below-cursor-site {
+    border: solid 2px transparent;
+    border-radius: 50%;
+    position: relative;
+    left: -50%;
+  }
+}
 // Site colors
 .cursor.ParticipantCursor, // cursor
-.SitePositionsComponent-site.color  { // avatar
+.SitePositionsComponent-site.color, // avatar
+.avatar-below-cursor-site.color {
   &--site-1  { border-color: @ui-site-color-1; }
   &--site-2  { border-color: @ui-site-color-2; }
   &--site-3  { border-color: @ui-site-color-3; }


### PR DESCRIPTION
This is not a PR yet, but rather a first step to ask:

- Is this feature wanted?
- How do you feel about adding a config to enable/disable this feature?
- How the avatars could be bound to the editor area?
- How could it be automatically tested?

### Description of the Change

This features adds the site avatar below its cursor. To do so, it uses `TextEditor.decorateMarkerLayer` with type `overlay`.

The fact that it's added into the existing *markerLayersBySite* system has the benefit that the suppression on site disconnection is already handled.

### Alternate Designs

Other avatars are displayed in React elements, but it was more complicated to follow the cursor. I believe it perfectly fits as a use case of overlay decoration.

### Benefits

The participants follow more easily what others do.

### Possible Drawbacks

I saw the avatars are drawn above the bottom bar.

### Verification Process

Only manually tested for now.
